### PR TITLE
Add sivchari to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 reviewers:
   - JoelSpeed
   - jpbetz
+  - sivchari
 approvers:
   - JoelSpeed
   - jpbetz


### PR DESCRIPTION
/kind documentation

I'd like to nominate myself as a kube-api-linter reviewers.
I had learned a lot since before this repository were transferred. And I'd like to step up and continue it to learn.