### PR TITLE
unify marker definitions to markers package

### DIFF
--- a/pkg/analysis/maxlength/analyzer.go
+++ b/pkg/analysis/maxlength/analyzer.go
@@ -23,22 +23,13 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 const (
 	name = "maxlength"
-
-	kubebuilderMaxLength = "kubebuilder:validation:MaxLength"
-	kubebuilderEnum      = "kubebuilder:validation:Enum"
-	kubebuilderFormat    = "kubebuilder:validation:Format"
-
-	kubebuilderItemsMaxLength = "kubebuilder:validation:items:MaxLength"
-	kubebuilderItemsEnum      = "kubebuilder:validation:items:Enum"
-	kubebuilderItemsFormat    = "kubebuilder:validation:items:Format"
-
-	kubebuilderMaxItems = "kubebuilder:validation:MaxItems"
 )
 
 // Analyzer is the analyzer for the maxlength package.
@@ -56,14 +47,14 @@ func run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		checkField(pass, field, markersAccess)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Markers) {
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markershelper.Markers) {
 	if len(field.Names) == 0 || field.Names[0] == nil {
 		return
 	}
@@ -71,10 +62,10 @@ func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Mar
 	fieldName := field.Names[0].Name
 	prefix := fmt.Sprintf("field %s", fieldName)
 
-	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, kubebuilderMaxLength, needsStringMaxLength)
+	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
 }
 
-func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if utils.IsBasicType(pass, ident) { // Built-in type
 		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 
@@ -89,7 +80,7 @@ func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []
 	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
 }
 
-func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if ident.Name != "string" {
 		return
 	}
@@ -101,7 +92,7 @@ func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases [
 	}
 }
 
-func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	if tSpec.Name == nil {
 		return
 	}
@@ -112,7 +103,7 @@ func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, alia
 	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
 }
 
-func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix, marker string, needsMaxLength func(markershelper.MarkerSet) bool) {
 	switch typ := typeExpr.(type) {
 	case *ast.Ident:
 		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
@@ -123,7 +114,7 @@ func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliase
 	}
 }
 
-func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if arrayType.Elt != nil {
 		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
 			if ident.Name == "byte" {
@@ -133,7 +124,7 @@ func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node
 					NamePos: ident.NamePos,
 					Name:    "string",
 				}
-				checkString(pass, i, node, aliases, markersAccess, prefix, kubebuilderMaxLength, needsStringMaxLength)
+				checkString(pass, i, node, aliases, markersAccess, prefix, markers.KubebuilderMaxLengthMarker, needsStringMaxLength)
 
 				return
 			}
@@ -142,16 +133,16 @@ func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node
 		}
 	}
 
-	markers := getCombinedMarkers(markersAccess, node, aliases)
+	markerSet := getCombinedMarkers(markersAccess, node, aliases)
 
-	if !markers.Has(kubebuilderMaxItems) {
-		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, kubebuilderMaxItems)
+	if !markerSet.Has(markers.KubebuilderMaxItemsMarker) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, markers.KubebuilderMaxItemsMarker)
 	}
 }
 
-func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markershelper.Markers, prefix string) {
 	if ident.Obj == nil { // Built-in type
-		checkString(pass, ident, node, aliases, markersAccess, prefix, kubebuilderItemsMaxLength, needsItemsMaxLength)
+		checkString(pass, ident, node, aliases, markersAccess, prefix, markers.KubebuilderItemsMaxLengthMarker, needsItemsMaxLength)
 
 		return
 	}
@@ -163,13 +154,13 @@ func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node
 
 	// If the array element wasn't directly a string, allow a string alias to be used
 	// with either the items style markers or the on alias style markers.
-	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), kubebuilderMaxLength, func(ms markers.MarkerSet) bool {
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), markers.KubebuilderMaxLengthMarker, func(ms markershelper.MarkerSet) bool {
 		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
 	})
 }
 
-func getCombinedMarkers(markersAccess markers.Markers, node ast.Node, aliases []*ast.TypeSpec) markers.MarkerSet {
-	base := markers.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
+func getCombinedMarkers(markersAccess markershelper.Markers, node ast.Node, aliases []*ast.TypeSpec) markershelper.MarkerSet {
+	base := markershelper.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
 
 	for _, a := range aliases {
 		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
@@ -178,7 +169,7 @@ func getCombinedMarkers(markersAccess markers.Markers, node ast.Node, aliases []
 	return base
 }
 
-func getMarkers(markersAccess markers.Markers, node ast.Node) markers.MarkerSet {
+func getMarkers(markersAccess markershelper.Markers, node ast.Node) markershelper.MarkerSet {
 	switch t := node.(type) {
 	case *ast.Field:
 		return markersAccess.FieldMarkers(t)
@@ -192,10 +183,10 @@ func getMarkers(markersAccess markers.Markers, node ast.Node) markers.MarkerSet 
 // needsMaxLength returns true if the field needs a maximum length.
 // Fields do not need a maximum length if they are already marked with a maximum length,
 // or if they are an enum, or if they are a date, date-time or duration.
-func needsStringMaxLength(markerSet markers.MarkerSet) bool {
+func needsStringMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
-	case markerSet.Has(kubebuilderMaxLength),
-		markerSet.Has(kubebuilderEnum),
+	case markerSet.Has(markers.KubebuilderMaxLengthMarker),
+		markerSet.Has(markers.KubebuilderEnumMarker),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
 		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
@@ -205,10 +196,10 @@ func needsStringMaxLength(markerSet markers.MarkerSet) bool {
 	return true
 }
 
-func needsItemsMaxLength(markerSet markers.MarkerSet) bool {
+func needsItemsMaxLength(markerSet markershelper.MarkerSet) bool {
 	switch {
-	case markerSet.Has(kubebuilderItemsMaxLength),
-		markerSet.Has(kubebuilderItemsEnum),
+	case markerSet.Has(markers.KubebuilderItemsMaxLengthMarker),
+		markerSet.Has(markers.KubebuilderItemsEnumMarker),
 		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
 		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
 		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
@@ -219,9 +210,9 @@ func needsItemsMaxLength(markerSet markers.MarkerSet) bool {
 }
 
 func kubebuilderFormatWithValue(value string) string {
-	return fmt.Sprintf("%s:=%s", kubebuilderFormat, value)
+	return fmt.Sprintf("%s:=%s", markers.KubebuilderFormatMarker, value)
 }
 
 func kubebuilderItemsFormatWithValue(value string) string {
-	return fmt.Sprintf("%s:=%s", kubebuilderItemsFormat, value)
+	return fmt.Sprintf("%s:=%s", markers.KubebuilderItemsFormatMarker, value)
 }

--- a/pkg/analysis/optionalorrequired/analyzer.go
+++ b/pkg/analysis/optionalorrequired/analyzer.go
@@ -23,40 +23,23 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/config"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 const (
 	name = "optionalorrequired"
-
-	// OptionalMarker is the marker that indicates that a field is optional.
-	OptionalMarker = "optional"
-
-	// RequiredMarker is the marker that indicates that a field is required.
-	RequiredMarker = "required"
-
-	// KubebuilderOptionalMarker is the marker that indicates that a field is optional in kubebuilder.
-	KubebuilderOptionalMarker = "kubebuilder:validation:Optional"
-
-	// KubebuilderRequiredMarker is the marker that indicates that a field is required in kubebuilder.
-	KubebuilderRequiredMarker = "kubebuilder:validation:Required"
-
-	// K8sOptionalMarker is the marker that indicates that a field is optional in k8s declarative validation.
-	K8sOptionalMarker = "k8s:optional"
-
-	// K8sRequiredMarker is the marker that indicates that a field is required in k8s declarative validation.
-	K8sRequiredMarker = "k8s:required"
 )
 
 func init() {
-	markers.DefaultRegistry().Register(
-		OptionalMarker,
-		RequiredMarker,
-		KubebuilderOptionalMarker,
-		KubebuilderRequiredMarker,
-		K8sOptionalMarker,
-		K8sRequiredMarker,
+	markershelper.DefaultRegistry().Register(
+		markers.OptionalMarker,
+		markers.RequiredMarker,
+		markers.KubebuilderOptionalMarker,
+		markers.KubebuilderRequiredMarker,
+		markers.K8sOptionalMarker,
+		markers.K8sRequiredMarker,
 	)
 }
 
@@ -75,21 +58,21 @@ func newAnalyzer(cfg config.OptionalOrRequiredConfig) *analysis.Analyzer {
 	a := &analyzer{}
 
 	switch cfg.PreferredOptionalMarker {
-	case OptionalMarker:
-		a.primaryOptionalMarker = OptionalMarker
-		a.secondaryOptionalMarker = KubebuilderOptionalMarker
-	case KubebuilderOptionalMarker:
-		a.primaryOptionalMarker = KubebuilderOptionalMarker
-		a.secondaryOptionalMarker = OptionalMarker
+	case markers.OptionalMarker:
+		a.primaryOptionalMarker = markers.OptionalMarker
+		a.secondaryOptionalMarker = markers.KubebuilderOptionalMarker
+	case markers.KubebuilderOptionalMarker:
+		a.primaryOptionalMarker = markers.KubebuilderOptionalMarker
+		a.secondaryOptionalMarker = markers.OptionalMarker
 	}
 
 	switch cfg.PreferredRequiredMarker {
-	case RequiredMarker:
-		a.primaryRequiredMarker = RequiredMarker
-		a.secondaryRequiredMarker = KubebuilderRequiredMarker
-	case KubebuilderRequiredMarker:
-		a.primaryRequiredMarker = KubebuilderRequiredMarker
-		a.secondaryRequiredMarker = RequiredMarker
+	case markers.RequiredMarker:
+		a.primaryRequiredMarker = markers.RequiredMarker
+		a.secondaryRequiredMarker = markers.KubebuilderRequiredMarker
+	case markers.KubebuilderRequiredMarker:
+		a.primaryRequiredMarker = markers.KubebuilderRequiredMarker
+		a.secondaryRequiredMarker = markers.RequiredMarker
 	}
 
 	return &analysis.Analyzer{
@@ -106,11 +89,11 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		a.checkField(pass, field, markersAccess.FieldMarkers(field), jsonTagInfo)
 	})
 
-	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
 		a.checkTypeSpec(pass, typeSpec, markersAccess)
 	})
 
@@ -118,7 +101,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 }
 
 //nolint:cyclop
-func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet, fieldTagInfo extractjsontags.FieldTagInfo) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarkers markershelper.MarkerSet, fieldTagInfo extractjsontags.FieldTagInfo) {
 	if fieldTagInfo.Inline {
 		// Inline fields would have no effect if they were marked as optional/required.
 		return
@@ -169,24 +152,24 @@ func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarker
 	}
 }
 
-func (a *analyzer) checkK8sMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet, prefix string, hasEitherOptional, hasEitherRequired bool) {
-	hasK8sOptional := fieldMarkers.Has(K8sOptionalMarker)
-	hasK8sRequired := fieldMarkers.Has(K8sRequiredMarker)
+func (a *analyzer) checkK8sMarkers(pass *analysis.Pass, field *ast.Field, fieldMarkers markershelper.MarkerSet, prefix string, hasEitherOptional, hasEitherRequired bool) {
+	hasK8sOptional := fieldMarkers.Has(markers.K8sOptionalMarker)
+	hasK8sRequired := fieldMarkers.Has(markers.K8sRequiredMarker)
 
 	if hasK8sOptional && hasK8sRequired {
-		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, K8sOptionalMarker, K8sRequiredMarker)
+		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, markers.K8sOptionalMarker, markers.K8sRequiredMarker)
 	}
 
 	if hasK8sOptional && hasEitherRequired {
-		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, K8sOptionalMarker, RequiredMarker)
+		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, markers.K8sOptionalMarker, markers.RequiredMarker)
 	}
 
 	if hasK8sRequired && hasEitherOptional {
-		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, OptionalMarker, K8sRequiredMarker)
+		pass.Reportf(field.Pos(), "%s must not be marked as both %s and %s", prefix, markers.OptionalMarker, markers.K8sRequiredMarker)
 	}
 }
 
-func reportShouldReplaceSecondaryMarker(field *ast.Field, marker []markers.Marker, primaryMarker, secondaryMarker, prefix string) analysis.Diagnostic {
+func reportShouldReplaceSecondaryMarker(field *ast.Field, marker []markershelper.Marker, primaryMarker, secondaryMarker, prefix string) analysis.Diagnostic {
 	textEdits := make([]analysis.TextEdit, len(marker))
 
 	for i, m := range marker {
@@ -219,7 +202,7 @@ func reportShouldReplaceSecondaryMarker(field *ast.Field, marker []markers.Marke
 	}
 }
 
-func reportShouldRemoveSecondaryMarker(field *ast.Field, marker []markers.Marker, primaryMarker, secondaryMarker, prefix string) analysis.Diagnostic {
+func reportShouldRemoveSecondaryMarker(field *ast.Field, marker []markershelper.Marker, primaryMarker, secondaryMarker, prefix string) analysis.Diagnostic {
 	textEdits := make([]analysis.TextEdit, len(marker))
 
 	for i, m := range marker {
@@ -242,13 +225,13 @@ func reportShouldRemoveSecondaryMarker(field *ast.Field, marker []markers.Marker
 	}
 }
 
-func (a *analyzer) checkTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
+func (a *analyzer) checkTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec, markersAccess markershelper.Markers) {
 	name := typeSpec.Name.Name
 	set := markersAccess.TypeMarkers(typeSpec)
 
 	for _, marker := range set.UnsortedList() {
 		switch marker.Identifier {
-		case a.primaryOptionalMarker, a.secondaryOptionalMarker, a.primaryRequiredMarker, a.secondaryRequiredMarker, K8sOptionalMarker, K8sRequiredMarker:
+		case a.primaryOptionalMarker, a.secondaryOptionalMarker, a.primaryRequiredMarker, a.secondaryRequiredMarker, markers.K8sOptionalMarker, markers.K8sRequiredMarker:
 			pass.Report(analysis.Diagnostic{
 				Pos:     typeSpec.Pos(),
 				Message: fmt.Sprintf("type %s should not be marked as %s", name, marker.String()),
@@ -271,10 +254,10 @@ func (a *analyzer) checkTypeSpec(pass *analysis.Pass, typeSpec *ast.TypeSpec, ma
 
 func defaultConfig(cfg *config.OptionalOrRequiredConfig) {
 	if cfg.PreferredOptionalMarker == "" {
-		cfg.PreferredOptionalMarker = OptionalMarker
+		cfg.PreferredOptionalMarker = markers.OptionalMarker
 	}
 
 	if cfg.PreferredRequiredMarker == "" {
-		cfg.PreferredRequiredMarker = RequiredMarker
+		cfg.PreferredRequiredMarker = markers.RequiredMarker
 	}
 }

--- a/pkg/analysis/optionalorrequired/analyzer_test.go
+++ b/pkg/analysis/optionalorrequired/analyzer_test.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
 	"sigs.k8s.io/kube-api-linter/pkg/config"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 func TestDefaultConfiguration(t *testing.T) {
@@ -39,8 +40,8 @@ func TestSwappedMarkerPriority(t *testing.T) {
 
 	a, err := optionalorrequired.Initializer().Init(config.LintersConfig{
 		OptionalOrRequired: config.OptionalOrRequiredConfig{
-			PreferredOptionalMarker: optionalorrequired.KubebuilderOptionalMarker,
-			PreferredRequiredMarker: optionalorrequired.KubebuilderRequiredMarker,
+			PreferredOptionalMarker: markers.KubebuilderOptionalMarker,
+			PreferredRequiredMarker: markers.KubebuilderRequiredMarker,
 		},
 	})
 	if err != nil {

--- a/pkg/analysis/requiredfields/analyzer.go
+++ b/pkg/analysis/requiredfields/analyzer.go
@@ -24,19 +24,17 @@ import (
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/config"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 const (
 	name = "requiredfields"
-
-	requiredMarker            = "required"
-	kubebuilderRequiredMarker = "kubebuilder:validation:Required"
 )
 
 func init() {
-	markers.DefaultRegistry().Register(requiredMarker, kubebuilderRequiredMarker)
+	markershelper.DefaultRegistry().Register(markers.RequiredMarker, markers.KubebuilderRequiredMarker)
 }
 
 type analyzer struct {
@@ -65,21 +63,21 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
 		a.checkField(pass, field, markersAccess.FieldMarkers(field), jsonTagInfo)
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarkers markers.MarkerSet, fieldTagInfo extractjsontags.FieldTagInfo) {
+func (a *analyzer) checkField(pass *analysis.Pass, field *ast.Field, fieldMarkers markershelper.MarkerSet, fieldTagInfo extractjsontags.FieldTagInfo) {
 	if field == nil || len(field.Names) == 0 {
 		return
 	}
 
 	fieldName := field.Names[0].Name
 
-	if !fieldMarkers.Has(requiredMarker) && !fieldMarkers.Has(kubebuilderRequiredMarker) {
+	if !fieldMarkers.Has(markers.RequiredMarker) && !fieldMarkers.Has(markers.KubebuilderRequiredMarker) {
 		// The field is not marked required, so we don't need to check it.
 		return
 	}

--- a/pkg/analysis/statussubresource/analyzer.go
+++ b/pkg/analysis/statussubresource/analyzer.go
@@ -25,19 +25,14 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
 	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 )
 
 const (
 	name = "statussubresource"
 
 	statusJSONTag = "status"
-
-	// kubebuilderRootMarker is the marker that indicates that a struct is the object root for code and CRD generation.
-	kubebuilderRootMarker = "kubebuilder:object:root:=true"
-
-	// kubebuilderStatusSubresourceMarker is the marker that indicates that the CRD generated for a struct should include the /status subresource.
-	kubebuilderStatusSubresourceMarker = "kubebuilder:subresource:status"
 )
 
 type analyzer struct{}
@@ -50,7 +45,7 @@ func newAnalyzer() *analysis.Analyzer {
 		Name:     name,
 		Doc:      "Checks that a type marked with kubebuilder:object:root:=true and containing a status field is marked with kubebuilder:subresource:status",
 		Run:      a.run,
-		Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer, extractjsontags.Analyzer},
+		Requires: []*analysis.Analyzer{inspect.Analyzer, markershelper.Analyzer, extractjsontags.Analyzer},
 	}
 }
 
@@ -60,7 +55,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, kalerrors.ErrCouldNotGetInspector
 	}
 
-	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	markersAccess, ok := pass.ResultOf[markershelper.Analyzer].(markershelper.Markers)
 	if !ok {
 		return nil, kalerrors.ErrCouldNotGetMarkers
 	}
@@ -99,16 +94,16 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	return nil, nil //nolint:nilnil
 }
 
-func (a *analyzer) checkStruct(pass *analysis.Pass, sTyp *ast.StructType, name string, structMarkers markers.MarkerSet, jsonTags extractjsontags.StructFieldTags) {
+func (a *analyzer) checkStruct(pass *analysis.Pass, sTyp *ast.StructType, name string, structMarkers markershelper.MarkerSet, jsonTags extractjsontags.StructFieldTags) {
 	if sTyp == nil {
 		return
 	}
 
-	if !structMarkers.HasWithValue(kubebuilderRootMarker) {
+	if !structMarkers.HasWithValue(formatKubeBuilderMarkerWithValue(markers.KubebuilderRootMarker, "true")) {
 		return
 	}
 
-	hasStatusSubresourceMarker := structMarkers.Has(kubebuilderStatusSubresourceMarker)
+	hasStatusSubresourceMarker := structMarkers.Has(markers.KubebuilderStatusSubresourceMarker)
 	hasStatusField := hasStatusField(sTyp, jsonTags)
 
 	switch {
@@ -117,12 +112,12 @@ func (a *analyzer) checkStruct(pass *analysis.Pass, sTyp *ast.StructType, name s
 	case hasStatusSubresourceMarker && !hasStatusField:
 		// Might be able to have some suggested fixes here, but it is likely much more complex
 		// so for now leave it with a descriptive failure message.
-		pass.Reportf(sTyp.Pos(), "root object type %q is marked to enable the status subresource with marker %q but has no status field", name, kubebuilderStatusSubresourceMarker)
+		pass.Reportf(sTyp.Pos(), "root object type %q is marked to enable the status subresource with marker %q but has no status field", name, markers.KubebuilderStatusSubresourceMarker)
 	case !hasStatusSubresourceMarker && hasStatusField:
 		// In this case we can suggest the autofix to add the status subresource marker
 		pass.Report(analysis.Diagnostic{
 			Pos:     sTyp.Pos(),
-			Message: fmt.Sprintf("root object type %q has a status field but does not have the marker %q to enable the status subresource", name, kubebuilderStatusSubresourceMarker),
+			Message: fmt.Sprintf("root object type %q has a status field but does not have the marker %q to enable the status subresource", name, markers.KubebuilderStatusSubresourceMarker),
 			SuggestedFixes: []analysis.SuggestedFix{
 				{
 					Message: "should add the kubebuilder:subresource:status marker",
@@ -157,4 +152,8 @@ func hasStatusField(sTyp *ast.StructType, jsonTags extractjsontags.StructFieldTa
 	}
 
 	return false
+}
+
+func formatKubeBuilderMarkerWithValue(marker, value string) string {
+	return fmt.Sprintf("%s:=%s", marker, value)
 }

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package markers
+
+const (
+	// OptionalMarker is the marker that indicates that a field is optional.
+	OptionalMarker = "optional"
+
+	// RequiredMarker is the marker that indicates that a field is required.
+	RequiredMarker = "required"
+)
+
+const (
+	// KubebuilderRootMarker is the marker that indicates that a struct is the object root for code and CRD generation.
+	KubebuilderRootMarker = "kubebuilder:object:root"
+
+	// KubebuilderStatusSubresourceMarker is the marker that indicates that the CRD generated for a struct should include the /status subresource.
+	KubebuilderStatusSubresourceMarker = "kubebuilder:subresource:status"
+
+	// KubebuilderEnumMarker is the marker that indicates that a field has an enum in kubebuilder.
+	KubebuilderEnumMarker = "kubebuilder:validation:Enum"
+
+	// KubebuilderFormatMarker is the marker that indicates that a field has a format in kubebuilder.
+	KubebuilderFormatMarker = "kubebuilder:validation:Format"
+
+	// KubebuilderMaxItemsMarker is the marker that indicates that a field has a maximum number of items in kubebuilder.
+	KubebuilderMaxItemsMarker = "kubebuilder:validation:MaxItems"
+
+	// KubebuilderMaxLengthMarker is the marker that indicates that a field has a maximum length in kubebuilder.
+	KubebuilderMaxLengthMarker = "kubebuilder:validation:MaxLength"
+
+	// KubebuilderOptionalMarker is the marker that indicates that a field is optional in kubebuilder.
+	KubebuilderOptionalMarker = "kubebuilder:validation:Optional"
+
+	// KubebuilderRequiredMarker is the marker that indicates that a field is required in kubebuilder.
+	KubebuilderRequiredMarker = "kubebuilder:validation:Required"
+
+	// KubebuilderItemsMaxLengthMarker is the marker that indicates that a field has a maximum length in kubebuilder.
+	KubebuilderItemsMaxLengthMarker = "kubebuilder:validation:items:MaxLength"
+
+	// KubebuilderItemsEnumMarker is the marker that indicates that a field has an enum in kubebuilder.
+	KubebuilderItemsEnumMarker = "kubebuilder:validation:items:Enum"
+
+	// KubebuilderItemsFormatMarker is the marker that indicates that a field has a format in kubebuilder.
+	KubebuilderItemsFormatMarker = "kubebuilder:validation:items:Format"
+)
+
+const (
+	// K8sOptionalMarker is the marker that indicates that a field is optional in k8s declarative validation.
+	K8sOptionalMarker = "k8s:optional"
+
+	// K8sRequiredMarker is the marker that indicates that a field is required in k8s declarative validation.
+	K8sRequiredMarker = "k8s:required"
+)

--- a/pkg/validation/linters_config.go
+++ b/pkg/validation/linters_config.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
 	"sigs.k8s.io/kube-api-linter/pkg/config"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -95,15 +95,15 @@ func validateOptionalOrRequiredConfig(oorc config.OptionalOrRequiredConfig, fldP
 	fieldErrors := field.ErrorList{}
 
 	switch oorc.PreferredOptionalMarker {
-	case "", optionalorrequired.OptionalMarker, optionalorrequired.KubebuilderOptionalMarker:
+	case "", markers.OptionalMarker, markers.KubebuilderOptionalMarker:
 	default:
-		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredOptionalMarker"), oorc.PreferredOptionalMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", optionalorrequired.OptionalMarker, optionalorrequired.KubebuilderOptionalMarker)))
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredOptionalMarker"), oorc.PreferredOptionalMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.OptionalMarker, markers.KubebuilderOptionalMarker)))
 	}
 
 	switch oorc.PreferredRequiredMarker {
-	case "", optionalorrequired.RequiredMarker, optionalorrequired.KubebuilderRequiredMarker:
+	case "", markers.RequiredMarker, markers.KubebuilderRequiredMarker:
 	default:
-		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredRequiredMarker"), oorc.PreferredRequiredMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", optionalorrequired.RequiredMarker, optionalorrequired.KubebuilderRequiredMarker)))
+		fieldErrors = append(fieldErrors, field.Invalid(fldPath.Child("preferredRequiredMarker"), oorc.PreferredRequiredMarker, fmt.Sprintf("invalid value, must be one of %q, %q or omitted", markers.RequiredMarker, markers.KubebuilderRequiredMarker)))
 	}
 
 	return fieldErrors

--- a/pkg/validation/linters_config_test.go
+++ b/pkg/validation/linters_config_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kube-api-linter/pkg/config"
+	"sigs.k8s.io/kube-api-linter/pkg/markers"
 	"sigs.k8s.io/kube-api-linter/pkg/validation"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -224,8 +225,8 @@ var _ = Describe("LintersConfig", func() {
 		Entry("With a valid OptionalOrRequiredConfig", validateLintersConfigTableInput{
 			config: config.LintersConfig{
 				OptionalOrRequired: config.OptionalOrRequiredConfig{
-					PreferredOptionalMarker: "optional",
-					PreferredRequiredMarker: "required",
+					PreferredOptionalMarker: markers.OptionalMarker,
+					PreferredRequiredMarker: markers.RequiredMarker,
 				},
 			},
 			expectedErr: "",
@@ -233,8 +234,8 @@ var _ = Describe("LintersConfig", func() {
 		Entry("With kubebuilder preferred markers", validateLintersConfigTableInput{
 			config: config.LintersConfig{
 				OptionalOrRequired: config.OptionalOrRequiredConfig{
-					PreferredOptionalMarker: "kubebuilder:validation:Optional",
-					PreferredRequiredMarker: "kubebuilder:validation:Required",
+					PreferredOptionalMarker: markers.KubebuilderOptionalMarker,
+					PreferredRequiredMarker: markers.KubebuilderRequiredMarker,
 				},
 			},
 			expectedErr: "",


### PR DESCRIPTION
Each linter definitions marker constant in themself, then there are some duplicated markers. In the future, we should add other marker definition to diagnose markers. So it's good to determine the location to define marker right now.

/kind cleanup
