### PR TITLE
Add declarative validation linting to optionalorrequired

### DIFF
--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go
@@ -41,6 +41,47 @@ type OptionalOrRequiredTestStruct struct {
 	// +optional
 	MarkedWithKubeBuilderOptionalTwiceAndOptional string // want "field MarkedWithKubeBuilderOptionalTwiceAndOptional should use only the marker optional, kubebuilder:validation:Optional is not required"
 
+	// MarkedWithK8sRequiredAndKubeBuilderRequired is a field with both k8s and kubebuilder required markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Required
+	// +kubebuilder:validation:Required
+	MarkedWithK8sRequiredAndKubeBuilderRequired string // want "field MarkedWithK8sRequiredAndKubeBuilderRequired should use marker required instead of kubebuilder:validation:Required"
+
+	// MarkedWithK8sRequiredAndRequired is a field with both k8s and required markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Required
+	// +required
+	MarkedWithK8sRequiredAndRequired string
+
+	// MarkedWithK8sOptionalAndKubeBuilderOptional is a field with both k8s and kubebuilder optional markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Optional
+	// +kubebuilder:validation:Optional
+	MarkedWithK8sOptionalAndKubeBuilderOptional string // want "field MarkedWithK8sOptionalAndKubeBuilderOptional should use marker optional instead of kubebuilder:validation:Optional"
+
+	// MarkedWithK8sOptionalAndOptional is a field with both k8s and optional markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Optional
+	// +optional
+	MarkedWithK8sOptionalAndOptional string
+
+	// MarkedWithK8sOptionalAndRequired is a field with both k8s and required markers.
+	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
+	// +k8s:Optional
+	// +required
+	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:Optional and required"
+
+	// MarkedWithK8sRequiredAndOptional is a field with both k8s and optional markers.
+	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
+	// +k8s:Required
+	// +optional
+	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:Required"
+
+	// MarkedWithK8sRequiredAndK8sOptional is a field with both k8s and kubebuilder optional markers.
+	// +k8s:Required
+	// +k8s:Optional
+	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:Optional and k8s:Required"
+
 	A `json:",inline"`
 
 	B `json:"b,omitempty"` // want "embedded field B must be marked as optional or required"

--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
@@ -36,6 +36,47 @@ type OptionalOrRequiredTestStruct struct {
 	// +optional
 	MarkedWithKubeBuilderOptionalTwiceAndOptional string // want "field MarkedWithKubeBuilderOptionalTwiceAndOptional should use only the marker optional, kubebuilder:validation:Optional is not required"
 
+    // MarkedWithK8sRequiredAndKubeBuilderRequired is a field with both k8s and kubebuilder required markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Required
+	// +required
+	MarkedWithK8sRequiredAndKubeBuilderRequired string // want "field MarkedWithK8sRequiredAndKubeBuilderRequired should use marker required instead of kubebuilder:validation:Required"
+
+	// MarkedWithK8sRequiredAndRequired is a field with both k8s and required markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Required
+	// +required
+	MarkedWithK8sRequiredAndRequired string
+
+	// MarkedWithK8sOptionalAndKubeBuilderOptional is a field with both k8s and kubebuilder optional markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Optional
+	// +optional
+	MarkedWithK8sOptionalAndKubeBuilderOptional string // want "field MarkedWithK8sOptionalAndKubeBuilderOptional should use marker optional instead of kubebuilder:validation:Optional"
+
+	// MarkedWithK8sOptionalAndOptional is a field with both k8s and optional markers.
+	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
+	// +k8s:Optional
+	// +optional
+	MarkedWithK8sOptionalAndOptional string
+
+	// MarkedWithK8sOptionalAndRequired is a field with both k8s and required markers.
+	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
+	// +k8s:Optional
+	// +required
+	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:Optional and required"
+
+	// MarkedWithK8sRequiredAndOptional is a field with both k8s and optional markers.
+	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
+	// +k8s:Required
+	// +optional
+	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:Required"
+
+	// MarkedWithK8sRequiredAndK8sOptional is a field with both k8s and kubebuilder optional markers.
+	// +k8s:Required
+	// +k8s:Optional
+	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:Optional and k8s:Required"
+
 	A `json:",inline"`
 
 	B `json:"b,omitempty"` // want "embedded field B must be marked as optional or required"

--- a/pkg/analysis/optionalorrequired/testdata/src/c/c.go
+++ b/pkg/analysis/optionalorrequired/testdata/src/c/c.go
@@ -18,6 +18,10 @@ type RequiredEnum string // want "type RequiredEnum should not be marked as requ
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type KubeBuilderRequiredEnum string // want "type KubeBuilderRequiredEnum should not be marked as kubebuilder:validation:Required"
 
+// +k8s:Required
+// +kubebuilder:validation:Enum=Foo;Bar;Baz
+type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:Required"
+
 // +optional
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type OptionalEnum string // want "type OptionalEnum should not be marked as optional"
@@ -25,3 +29,7 @@ type OptionalEnum string // want "type OptionalEnum should not be marked as opti
 // +kubebuilder:validation:Optional
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type KubeBuilderOptionalEnum string // want "type KubeBuilderOptionalEnum should not be marked as kubebuilder:validation:Optional"
+
+// +k8s:Optional
+// +kubebuilder:validation:Enum=Foo;Bar;Baz
+type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:Optional"

--- a/pkg/analysis/optionalorrequired/testdata/src/c/c.go.golden
+++ b/pkg/analysis/optionalorrequired/testdata/src/c/c.go.golden
@@ -17,7 +17,13 @@ type RequiredEnum string // want "type RequiredEnum should not be marked as requ
 type KubeBuilderRequiredEnum string // want "type KubeBuilderRequiredEnum should not be marked as kubebuilder:validation:Required"
 
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
+type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:Required"
+
+// +kubebuilder:validation:Enum=Foo;Bar;Baz
 type OptionalEnum string // want "type OptionalEnum should not be marked as optional"
 
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type KubeBuilderOptionalEnum string // want "type KubeBuilderOptionalEnum should not be marked as kubebuilder:validation:Optional"
+
+// +kubebuilder:validation:Enum=Foo;Bar;Baz
+type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:Optional"


### PR DESCRIPTION
This PR updates the `optionalorrequired` linter to also understand the semantics of the `+k8s:Optional` and `+k8s:Required` markers.

In particular, it checks that both are not set at the same time, and, that if another optiona/required marker is present, that the semantics match.

CC @yongruilin 