### PR TITLE
k8s:optional and k8s:required should be lowercase

### DIFF
--- a/pkg/analysis/optionalorrequired/analyzer.go
+++ b/pkg/analysis/optionalorrequired/analyzer.go
@@ -43,10 +43,10 @@ const (
 	KubebuilderRequiredMarker = "kubebuilder:validation:Required"
 
 	// K8sOptionalMarker is the marker that indicates that a field is optional in k8s declarative validation.
-	K8sOptionalMarker = "k8s:Optional"
+	K8sOptionalMarker = "k8s:optional"
 
 	// K8sRequiredMarker is the marker that indicates that a field is required in k8s declarative validation.
-	K8sRequiredMarker = "k8s:Required"
+	K8sRequiredMarker = "k8s:required"
 )
 
 func init() {

--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go
@@ -43,44 +43,44 @@ type OptionalOrRequiredTestStruct struct {
 
 	// MarkedWithK8sRequiredAndKubeBuilderRequired is a field with both k8s and kubebuilder required markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Required
+	// +k8s:required
 	// +kubebuilder:validation:Required
 	MarkedWithK8sRequiredAndKubeBuilderRequired string // want "field MarkedWithK8sRequiredAndKubeBuilderRequired should use marker required instead of kubebuilder:validation:Required"
 
 	// MarkedWithK8sRequiredAndRequired is a field with both k8s and required markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Required
+	// +k8s:required
 	// +required
 	MarkedWithK8sRequiredAndRequired string
 
 	// MarkedWithK8sOptionalAndKubeBuilderOptional is a field with both k8s and kubebuilder optional markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Optional
+	// +k8s:optional
 	// +kubebuilder:validation:Optional
 	MarkedWithK8sOptionalAndKubeBuilderOptional string // want "field MarkedWithK8sOptionalAndKubeBuilderOptional should use marker optional instead of kubebuilder:validation:Optional"
 
 	// MarkedWithK8sOptionalAndOptional is a field with both k8s and optional markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Optional
+	// +k8s:optional
 	// +optional
 	MarkedWithK8sOptionalAndOptional string
 
 	// MarkedWithK8sOptionalAndRequired is a field with both k8s and required markers.
 	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
-	// +k8s:Optional
+	// +k8s:optional
 	// +required
-	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:Optional and required"
+	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:optional and required"
 
 	// MarkedWithK8sRequiredAndOptional is a field with both k8s and optional markers.
 	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
-	// +k8s:Required
+	// +k8s:required
 	// +optional
-	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:Required"
+	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:required"
 
 	// MarkedWithK8sRequiredAndK8sOptional is a field with both k8s and kubebuilder optional markers.
-	// +k8s:Required
-	// +k8s:Optional
-	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:Optional and k8s:Required"
+	// +k8s:required
+	// +k8s:optional
+	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:optional and k8s:required"
 
 	A `json:",inline"`
 

--- a/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalorrequired/testdata/src/a/a.go.golden
@@ -38,44 +38,44 @@ type OptionalOrRequiredTestStruct struct {
 
     // MarkedWithK8sRequiredAndKubeBuilderRequired is a field with both k8s and kubebuilder required markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Required
+	// +k8s:required
 	// +required
 	MarkedWithK8sRequiredAndKubeBuilderRequired string // want "field MarkedWithK8sRequiredAndKubeBuilderRequired should use marker required instead of kubebuilder:validation:Required"
 
 	// MarkedWithK8sRequiredAndRequired is a field with both k8s and required markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Required
+	// +k8s:required
 	// +required
 	MarkedWithK8sRequiredAndRequired string
 
 	// MarkedWithK8sOptionalAndKubeBuilderOptional is a field with both k8s and kubebuilder optional markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Optional
+	// +k8s:optional
 	// +optional
 	MarkedWithK8sOptionalAndKubeBuilderOptional string // want "field MarkedWithK8sOptionalAndKubeBuilderOptional should use marker optional instead of kubebuilder:validation:Optional"
 
 	// MarkedWithK8sOptionalAndOptional is a field with both k8s and optional markers.
 	// The k8s versions of the markers are currently in addition to other markers so this is accepted.
-	// +k8s:Optional
+	// +k8s:optional
 	// +optional
 	MarkedWithK8sOptionalAndOptional string
 
 	// MarkedWithK8sOptionalAndRequired is a field with both k8s and required markers.
 	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
-	// +k8s:Optional
+	// +k8s:optional
 	// +required
-	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:Optional and required"
+	MarkedWithK8sOptionalAndRequired string // want "field MarkedWithK8sOptionalAndRequired must not be marked as both k8s:optional and required"
 
 	// MarkedWithK8sRequiredAndOptional is a field with both k8s and optional markers.
 	// The k8s versions of the markers are currently in addition to other markers, but they should match the semantics.
-	// +k8s:Required
+	// +k8s:required
 	// +optional
-	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:Required"
+	MarkedWithK8sRequiredAndOptional string // want "field MarkedWithK8sRequiredAndOptional must not be marked as both optional and k8s:required"
 
 	// MarkedWithK8sRequiredAndK8sOptional is a field with both k8s and kubebuilder optional markers.
-	// +k8s:Required
-	// +k8s:Optional
-	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:Optional and k8s:Required"
+	// +k8s:required
+	// +k8s:optional
+	MarkedWithK8sRequiredAndK8sOptional string // want "field MarkedWithK8sRequiredAndK8sOptional must be marked as optional or required" "field MarkedWithK8sRequiredAndK8sOptional must not be marked as both k8s:optional and k8s:required"
 
 	A `json:",inline"`
 

--- a/pkg/analysis/optionalorrequired/testdata/src/c/c.go
+++ b/pkg/analysis/optionalorrequired/testdata/src/c/c.go
@@ -18,9 +18,9 @@ type RequiredEnum string // want "type RequiredEnum should not be marked as requ
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type KubeBuilderRequiredEnum string // want "type KubeBuilderRequiredEnum should not be marked as kubebuilder:validation:Required"
 
-// +k8s:Required
+// +k8s:required
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
-type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:Required"
+type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:required"
 
 // +optional
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
@@ -30,6 +30,6 @@ type OptionalEnum string // want "type OptionalEnum should not be marked as opti
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type KubeBuilderOptionalEnum string // want "type KubeBuilderOptionalEnum should not be marked as kubebuilder:validation:Optional"
 
-// +k8s:Optional
+// +k8s:optional
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
-type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:Optional"
+type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:optional"

--- a/pkg/analysis/optionalorrequired/testdata/src/c/c.go.golden
+++ b/pkg/analysis/optionalorrequired/testdata/src/c/c.go.golden
@@ -17,7 +17,7 @@ type RequiredEnum string // want "type RequiredEnum should not be marked as requ
 type KubeBuilderRequiredEnum string // want "type KubeBuilderRequiredEnum should not be marked as kubebuilder:validation:Required"
 
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
-type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:Required"
+type K8sRequiredEnum string // want "type K8sRequiredEnum should not be marked as k8s:required"
 
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
 type OptionalEnum string // want "type OptionalEnum should not be marked as optional"
@@ -26,4 +26,4 @@ type OptionalEnum string // want "type OptionalEnum should not be marked as opti
 type KubeBuilderOptionalEnum string // want "type KubeBuilderOptionalEnum should not be marked as kubebuilder:validation:Optional"
 
 // +kubebuilder:validation:Enum=Foo;Bar;Baz
-type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:Optional"
+type K8sOptionalEnum string // want "type K8sOptionalEnum should not be marked as k8s:optional"


### PR DESCRIPTION
These got uppercased through a hallucination this morning (I thought I'd checked against the existing implementation in validation-gen).

Thanks to @liggitt and @thockin for noticing