### PR TITLE
add uniquemarkers linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,36 @@ This linter is not enabled by default as it is only applicable to CustomResource
 In the case where there is a status field present but no `kubebuilder:subresource:status` marker, the
 linter will suggest adding the comment `// +kubebuilder:subresource:status` above the struct.
 
+## UniqueMarkers
+
+The `uniquemarkers` linter ensures that types and fields do not contain more than a single definition of a marker that should only be present once.
+
+Because this linter has no way of determining which marker definition was intended it does not suggest any fixes 
+
+### Configuration
+It can configured to include a set of custom markers in the analysis by setting:
+```yaml
+lintersConfig:
+  uniqueMarkers:
+    customMarkers:
+      - identifier: custom:SomeCustomMarker
+        attributes:
+          - fruit
+```
+
+For each custom marker, it must specify an `identifier` and optionally some `attributes`.
+As an example, take the marker definition `kubebuilder:validation:XValidation:rule='has(self.foo)',message='should have foo',fieldPath='.foo'`.
+The identifier for the marker is `kubebuilder:validation:XValidation` and its attributes are `rule`, `message`, and `fieldPath`.
+
+When specifying `attributes`, those attributes are included in the uniqueness identification of a marker definition.
+
+Taking the example configuration from above:
+
+- Marker definitions of `custom:SomeCustomMarker:fruit=apple,color=red` and `custom:SomeCustomMarker:fruit=apple,color=green` would violate the uniqueness requirement and be flagged.
+- Marker definitions of `custom:SomeCustomMarker:fruit=apple,color=red` and `custom:SomeCustomMarker:fruit=orange,color=red` would _not_ violate the uniqueness requirement.
+
+Each entry in `customMarkers` must have a unique `identifier`.
+
 # Contributing
 
 New linters can be added by following the [New Linter][new-linter] guide.

--- a/pkg/analysis/optionalfields/util.go
+++ b/pkg/analysis/optionalfields/util.go
@@ -193,7 +193,7 @@ func isStructZeroValueValid(pass *analysis.Pass, field *ast.Field, structType *a
 
 	zeroValueValid, nonOmittedFields := areStructFieldZeroValuesValid(pass, structType, markersAccess, jsonTagInfo)
 
-	markerSet := combinedMarkers(markersAccess, field, structType)
+	markerSet := utils.TypeAwareMarkerCollectionForField(pass, markersAccess, field)
 
 	minProperties, err := getMarkerNumericValueByName[int](markerSet, markers.KubebuilderMinPropertiesMarker)
 	if err != nil && !errors.Is(err, errMarkerMissingValue) {
@@ -330,15 +330,6 @@ func enumFieldAllowsEmpty(fieldMarkers markershelper.MarkerSet) bool {
 	}
 
 	return false
-}
-
-func combinedMarkers(markersAccess markershelper.Markers, field *ast.Field, structType *ast.StructType) markershelper.MarkerSet {
-	markers := markersAccess.FieldMarkers(field)
-	structMarkers := markersAccess.StructMarkers(structType)
-
-	markers.Insert(structMarkers.UnsortedList()...)
-
-	return markers
 }
 
 // number is a type constraint for numeric types.

--- a/pkg/analysis/uniquemarkers/analyzer.go
+++ b/pkg/analysis/uniquemarkers/analyzer.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package uniquemarkers
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"sigs.k8s.io/kube-api-linter/pkg/config"
+	markersconsts "sigs.k8s.io/kube-api-linter/pkg/markers"
+)
+
+const name = "uniquemarkers"
+
+func init() {
+	for _, uniqueMarker := range defaultUniqueMarkers() {
+		markers.DefaultRegistry().Register(uniqueMarker.Identifier)
+	}
+}
+
+type analyzer struct {
+	uniqueMarkers []config.UniqueMarker
+}
+
+func newAnalyzer(cfg config.UniqueMarkersConfig) *analysis.Analyzer {
+	a := &analyzer{
+		uniqueMarkers: append(defaultUniqueMarkers(), cfg.CustomMarkers...),
+	}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Check that all markers that should be unique on a field/type are only present once",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer},
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, _ extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+		checkField(pass, field, markersAccess, a.uniqueMarkers)
+	})
+
+	inspect.InspectTypeSpec(func(typeSpec *ast.TypeSpec, markersAccess markers.Markers) {
+		checkType(pass, typeSpec, markersAccess, a.uniqueMarkers)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Markers, uniqueMarkers []config.UniqueMarker) {
+	if field == nil || len(field.Names) == 0 {
+		return
+	}
+
+	markers := utils.TypeAwareMarkerCollectionForField(pass, markersAccess, field)
+	check(markers, uniqueMarkers, reportField(pass, field))
+}
+
+func checkType(pass *analysis.Pass, typeSpec *ast.TypeSpec, markersAccess markers.Markers, uniqueMarkers []config.UniqueMarker) {
+	if typeSpec == nil {
+		return
+	}
+
+	markers := markersAccess.TypeMarkers(typeSpec)
+	check(markers, uniqueMarkers, reportType(pass, typeSpec))
+}
+
+func check(markerSet markers.MarkerSet, uniqueMarkers []config.UniqueMarker, reportFunc func(id string)) {
+	for _, marker := range uniqueMarkers {
+		marks := markerSet.Get(marker.Identifier)
+		markSet := sets.New[string]()
+
+		for _, mark := range marks {
+			id := constructIdentifier(mark, marker.Attributes...)
+
+			if markSet.Has(id) {
+				reportFunc(id)
+				continue
+			}
+
+			markSet.Insert(id)
+		}
+	}
+}
+
+// constructIdentifier returns a string that serves as a unique identifier for a
+// marker based on the provided attributes that should be unique for the marker.
+func constructIdentifier(marker markers.Marker, attributes ...string) string {
+	// if there are no unique attributes, the unique identifier is just
+	// the base marker identifier
+	if len(attributes) == 0 {
+		return marker.Identifier
+	}
+
+	// If a marker doesn't specify the attribute, we should assume it is equivalent
+	// to the empty string ("") so that we can still key on uniqueness of other attributes
+	// effectively.
+	id := fmt.Sprintf("%s:", marker.Identifier)
+	for _, attr := range attributes {
+		id += fmt.Sprintf("%s=%s,", attr, marker.Expressions[attr])
+	}
+
+	id = strings.TrimSuffix(id, ",")
+
+	return id
+}
+
+func reportField(pass *analysis.Pass, field *ast.Field) func(id string) {
+	return func(id string) {
+		pass.Report(analysis.Diagnostic{
+			Pos:     field.Pos(),
+			Message: fmt.Sprintf("field %s has multiple definitions of marker %s when only a single definition should exist", field.Names[0].Name, id),
+		})
+	}
+}
+
+func reportType(pass *analysis.Pass, typeSpec *ast.TypeSpec) func(id string) {
+	return func(id string) {
+		pass.Report(analysis.Diagnostic{
+			Pos:     typeSpec.Pos(),
+			Message: fmt.Sprintf("type %s has multiple definitions of marker %s when only a single definition should exist", typeSpec.Name, id),
+		})
+	}
+}
+
+//nolint:funlen
+func defaultUniqueMarkers() []config.UniqueMarker {
+	return []config.UniqueMarker{
+		// Basic unique markers
+		// ------
+		{
+			Identifier: markersconsts.DefaultMarker,
+		},
+		// ------
+
+		// Kubebuilder-specific unique markers
+		// ------
+		{
+			Identifier: markersconsts.KubebuilderDefaultMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderExampleMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderEnumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderExclusiveMaximumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderExclusiveMinimumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderFormatMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMaxItemsMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMaxLengthMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMaxPropertiesMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMaximumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMinItemsMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMinLengthMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMinPropertiesMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMinimumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderMultipleOfMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderPatternMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderTypeMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderUniqueItemsMarker,
+		},
+
+		{
+			Identifier: markersconsts.KubebuilderItemsEnumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsFormatMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMaxLengthMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMaxItemsMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMaxPropertiesMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMaximumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMinLengthMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMinItemsMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMinPropertiesMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMinimumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsExclusiveMaximumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsExclusiveMinimumMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsMultipleOfMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsPatternMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsTypeMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsUniqueItemsMarker,
+		},
+		{
+			Identifier: markersconsts.KubebuilderXValidationMarker,
+			Attributes: []string{
+				"rule",
+			},
+		},
+		{
+			Identifier: markersconsts.KubebuilderItemsXValidationMarker,
+			Attributes: []string{
+				"rule",
+			},
+		},
+		// ------
+	}
+}

--- a/pkg/analysis/uniquemarkers/analyzer_test.go
+++ b/pkg/analysis/uniquemarkers/analyzer_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package uniquemarkers
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/config"
+)
+
+func TestWithDefaults(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAnalyzer(config.UniqueMarkersConfig{}), "a/...")
+}
+
+func TestWithConfiguration(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, newAnalyzer(config.UniqueMarkersConfig{
+		CustomMarkers: []config.UniqueMarker{
+			{
+				Identifier: "custom:SomeCustomMarker",
+			},
+			{
+				Identifier: "custom:OtherMarker",
+				Attributes: []string{
+					"attribute",
+				},
+			},
+			{
+				Identifier: "custom:MultiMarker",
+				Attributes: []string{
+					"fruit",
+					"color",
+					"country",
+				},
+			},
+		},
+	}), "b/...")
+}

--- a/pkg/analysis/uniquemarkers/doc.go
+++ b/pkg/analysis/uniquemarkers/doc.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+* The `uniquemarkers` linter ensures that types and fields do not contain more than a single
+* definition of a marker that should only be present once.
+*
+* Because this linter has no way of determining which marker definition was intended it does not suggest any fixes.
+*
+* It can configured to include a set of custom markers in the analysis by setting:
+* ```yaml
+* lintersConfig:
+*   uniqueMarkers:
+*     customMarkers:
+*       - identifier: custom:SomeCustomMarker
+*         attributes:
+*           - fruit
+* ```
+* For each custom marker, it must specify an `identifier` and optionally some `attributes`.
+* As an example, take the marker definition `kubebuilder:validation:XValidation:rule='has(self.foo)',message='should have foo',fieldPath='.foo'`.
+* The identifier for the marker is `kubebuilder:validation:XValidation` and its attributes are `rule`, `message`, and `fieldPath`.
+*
+* When specifying `attributes`, those attributes are included in the uniqueness identification of a marker definition.
+*
+* Taking the example configuration from above:
+*
+* - Marker definitions of `custom:SomeCustomMarker:fruit=apple,color=red` and `custom:SomeCustomMarker:fruit=apple,color=green` would violate the uniqueness requirement and be flagged.
+* - Marker definitions of `custom:SomeCustomMarker:fruit=apple,color=red` and `custom:SomeCustomMarker:fruit=orange,color=red` would _not_ violate the uniqueness requirement.
+*
+* Each entry in `customMarkers` must have a unique `identifier`.
+ */
+package uniquemarkers

--- a/pkg/analysis/uniquemarkers/initializer.go
+++ b/pkg/analysis/uniquemarkers/initializer.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package uniquemarkers
+
+import (
+	"golang.org/x/tools/go/analysis"
+	"sigs.k8s.io/kube-api-linter/pkg/config"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg.UniqueMarkers), nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return true
+}

--- a/pkg/analysis/uniquemarkers/testdata/src/a/a.go
+++ b/pkg/analysis/uniquemarkers/testdata/src/a/a.go
@@ -1,0 +1,690 @@
+package a
+
+// +kubebuilder:validation:MinProperties:=3
+// +kubebuilder:validation:MinProperties:=5
+type A struct { // want "type A has multiple definitions of marker kubebuilder:validation:MinProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:XValidation:rule='self.matches("[0-9A-Za-z]")',message='should match regex'
+	// +kubebuilder:validation:XValidation:rule='isURL(self)',message='should be a URL'
+	AllowedNonUniqueMarkers string
+
+	// +kubebuilder:validation:XValidation:rule='self.matches("[0-9]")',message='should actually be a number'
+	// +kubebuilder:validation:XValidation:rule='self.matches("[0-9]")',message='different message'
+	NonUniqueXValidations string // want "field NonUniqueXValidations has multiple definitions of marker kubebuilder:validation:XValidation:rule='self\\.matches\\(\\\"\\[0-9]\\\"\\)' when only a single definition should exist"
+
+	// +kubebuilder:validation:items:XValidation:rule='self.matches("[0-9]")',message='should actually be a number'
+	// +kubebuilder:validation:items:XValidation:rule='self.matches("[0-9]")',message='different message'
+	NonUniqueItemsXValidations []string // want "field NonUniqueItemsXValidations has multiple definitions of marker kubebuilder:validation:items:XValidation:rule='self\\.matches\\(\\\"\\[0-9]\\\"\\)' when only a single definition should exist" 
+
+	// +kubebuilder:validation:XValidation:rule='self.matches("[a-z]")',message='same'
+	// +kubebuilder:validation:XValidation:rule='self.matches("[0-9]")',message='same'
+	UniqueXValidationsFromMessage string
+
+	// +custom:SomeCustomMarker:=value
+	// +custom:SomeCustomMarker:=diffvalue
+	CustomMarkers string
+
+	// +default:value="homer"
+	UniqueBasicDefault string
+
+	// +default:value="homer"
+	// +default:value="bart"
+	NonUniqueBasicDefault string // want "field NonUniqueBasicDefault has multiple definitions of marker default when only a single definition should exist"
+
+	// +default:value="homer"
+	NonUniqueBasicDefaultFromAliasWithBasicDefault UniqueBasicDefaultAlias // want "field NonUniqueBasicDefaultFromAliasWithBasicDefault has multiple definitions of marker default when only a single definition should exist"
+
+	NonUniqueBasicDefaultOnlyFromAliasWithBasicDefault NonUniqueBasicDefaultAlias // want "field NonUniqueBasicDefaultOnlyFromAliasWithBasicDefault has multiple definitions of marker default when only a single definition should exist"
+
+	// +kubebuilder:default:="homer"
+	UniqueKubebuilderDefault string
+
+	// +kubebuilder:default:="homer"
+	// +kubebuilder:default:="bart"
+	NonUniqueKubebuilderDefault string // want "field NonUniqueKubebuilderDefault has multiple definitions of marker kubebuilder:default when only a single definition should exist"
+
+	// +kubebuilder:default:="homer"
+	NonUniqueKubebuilderDefaultFromAliasWithKubebuilderDefault UniqueKubebuilderDefaultAlias // want "field NonUniqueKubebuilderDefaultFromAliasWithKubebuilderDefault has multiple definitions of marker kubebuilder:default when only a single definition should exist"
+
+	NonUniqueKubebuilderDefaultOnlyFromAliasWithKubebuilderDefault NonUniqueKubebuilderDefaultAlias // want "field NonUniqueKubebuilderDefaultOnlyFromAliasWithKubebuilderDefault has multiple definitions of marker kubebuilder:default when only a single definition should exist"
+
+	// +kubebuilder:example:="homer"
+	UniqueKubebuilderExample string
+
+	// +kubebuilder:example:="homer"
+	// +kubebuilder:example:="bart"
+	NonUniqueKubebuilderExample string // want "field NonUniqueKubebuilderExample has multiple definitions of marker kubebuilder:example when only a single definition should exist"
+
+	// +kubebuilder:example:="homer"
+	NonUniqueKubebuilderExampleFromAliasWithKubebuilderExample UniqueKubebuilderExampleAlias // want "field NonUniqueKubebuilderExampleFromAliasWithKubebuilderExample has multiple definitions of marker kubebuilder:example when only a single definition should exist"
+
+	NonUniqueKubebuilderExampleOnlyFromAliasWithKubebuilderExample NonUniqueKubebuilderExampleAlias // want "field NonUniqueKubebuilderExampleOnlyFromAliasWithKubebuilderExample has multiple definitions of marker kubebuilder:example when only a single definition should exist"
+
+	// +kubebuilder:validation:MinLength:=1
+	UniqueMinLength string
+
+	// +kubebuilder:validation:MinLength:=1
+	// +kubebuilder:validation:MinLength:=5
+	NonUniqueMinLength string // want "field NonUniqueMinLength has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:MinLength:=1
+	NonUniqueMinLengthFromAliasWithMinLength UniqueMinLengthStringAlias // want "field NonUniqueMinLengthFromAliasWithMinLength has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	NonUniqueMinLengthOnlyFromAliasWithMinLength NonUniqueMinLengthStringAlias // want "field NonUniqueMinLengthOnlyFromAliasWithMinLength has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:Enum:=Foo;Bar
+	UniqueEnum string
+
+	// +kubebuilder:validation:Enum:=Foo;Bar
+	// +kubebuilder:validation:Enum:=Baz;Qux
+	NonUniqueEnum string // want "field NonUniqueEnum has multiple definitions of marker kubebuilder:validation:Enum when only a single definition should exist"
+
+	// +kubebuilder:validation:Enum:=Foo;Bar
+	NonUniqueEnumFromAliasWithEnum UniqueEnumAlias // want "field NonUniqueEnumFromAliasWithEnum has multiple definitions of marker kubebuilder:validation:Enum when only a single definition should exist"
+
+	NonUniqueEnumOnlyFromAliasWithEnum NonUniqueEnumAlias // want "field NonUniqueEnumOnlyFromAliasWithEnum has multiple definitions of marker kubebuilder:validation:Enum when only a single definition should exist"
+
+	// +kubebuilder:validation:Maximum:=10
+	// +kubebuilder:validation:ExclusiveMaximum:=true
+	UniqueExclusiveMaximum int
+
+	// +kubebuilder:validation:Maximum:=10
+	// +kubebuilder:validation:ExclusiveMaximum:=true
+	// +kubebuilder:validation:ExclusiveMaximum:=false
+	NonUniqueExclusiveMaximum int // want "field NonUniqueExclusiveMaximum has multiple definitions of marker kubebuilder:validation:ExclusiveMaximum when only a single definition should exist"
+
+	// +kubebuilder:validation:ExclusiveMaximum:=true
+	NonUniqueExclusiveMaximumFromAliasWithExclusiveMaximum UniqueExclusiveMaximumAlias // want "field NonUniqueExclusiveMaximumFromAliasWithExclusiveMaximum has multiple definitions of marker kubebuilder:validation:ExclusiveMaximum when only a single definition should exist"
+
+	NonUniqueExclusiveMaximumOnlyFromAliasWithExclusiveMaximum NonUniqueExclusiveMaximumAlias // want "field NonUniqueExclusiveMaximumOnlyFromAliasWithExclusiveMaximum has multiple definitions of marker kubebuilder:validation:ExclusiveMaximum when only a single definition should exist"
+
+	// +kubebuilder:validation:Minimum:=2
+	// +kubebuilder:validation:ExclusiveMinimum:=true
+	UniqueExclusiveMinimum int
+
+	// +kubebuilder:validation:Minimum:=2
+	// +kubebuilder:validation:ExclusiveMinimum:=true
+	// +kubebuilder:validation:ExclusiveMinimum:=false
+	NonUniqueExclusiveMinimum int // want "field NonUniqueExclusiveMinimum has multiple definitions of marker kubebuilder:validation:ExclusiveMinimum when only a single definition should exist"
+
+	// +kubebuilder:validation:ExclusiveMinimum:=true
+	NonUniqueExclusiveMinimumFromAliasWithExclusiveMinimum UniqueExclusiveMinimumAlias // want "field NonUniqueExclusiveMinimumFromAliasWithExclusiveMinimum has multiple definitions of marker kubebuilder:validation:ExclusiveMinimum when only a single definition should exist"
+
+	NonUniqueExclusiveMinimumOnlyFromAliasWithExclusiveMinimum NonUniqueExclusiveMinimumAlias // want "field NonUniqueExclusiveMinimumOnlyFromAliasWithExclusiveMinimum has multiple definitions of marker kubebuilder:validation:ExclusiveMinimum when only a single definition should exist"
+
+	// +kubebuilder:validation:Format:="date-time"
+	UniqueFormat string
+
+	// +kubebuilder:validation:Format:="date-time"
+	// +kubebuilder:validation:Format:="password"
+	NonUniqueFormat string // want "field NonUniqueFormat has multiple definitions of marker kubebuilder:validation:Format when only a single definition should exist"
+
+	// +kubebuilder:validation:Format:="password"
+	NonUniqueFormatFromAliasWithFormat UniqueFormatAlias // want "field NonUniqueFormatFromAliasWithFormat has multiple definitions of marker kubebuilder:validation:Format when only a single definition should exist"
+
+	NonUniqueFormatOnlyFromAliasWithFormat NonUniqueFormatAlias // want "field NonUniqueFormatOnlyFromAliasWithFormat has multiple definitions of marker kubebuilder:validation:Format when only a single definition should exist"
+
+	// +kubebuilder:validation:MaxItems:=10
+	UniqueMaxItems []string
+
+	// +kubebuilder:validation:MaxItems:=10
+	// +kubebuilder:validation:MaxItems:=5
+	NonUniqueMaxItems []string // want "field NonUniqueMaxItems has multiple definitions of marker kubebuilder:validation:MaxItems when only a single definition should exist"
+
+	// +kubebuilder:validation:MaxItems:=8
+	NonUniqueMaxItemsFromAliasWithMaxItems UniqueMaxItemsAlias // want "field NonUniqueMaxItemsFromAliasWithMaxItems has multiple definitions of marker kubebuilder:validation:MaxItems when only a single definition should exist"
+
+	NonUniqueMaxItemsOnlyFromAliasWithMaxItems NonUniqueMaxItemsAlias // want "field NonUniqueMaxItemsOnlyFromAliasWithMaxItems has multiple definitions of marker kubebuilder:validation:MaxItems when only a single definition should exist"
+
+	// +kubebuilder:validation:MaxProperties:=3
+	UniqueMaxProperties map[string]string
+
+	// +kubebuilder:validation:MaxProperties:=3
+	// +kubebuilder:validation:MaxProperties:=5
+	NonUniqueMaxProperties map[string]string // want "field NonUniqueMaxProperties has multiple definitions of marker kubebuilder:validation:MaxProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:MaxProperties:=4
+	NonUniqueMaxPropertiesFromAliasWithMaxProperties UniqueMaxPropertiesAlias // want "field NonUniqueMaxPropertiesFromAliasWithMaxProperties has multiple definitions of marker kubebuilder:validation:MaxProperties when only a single definition should exist"
+
+	NonUniqueMaxPropertiesOnlyFromAliasWithMaxProperties NonUniqueMaxPropertiesAlias // want "field NonUniqueMaxPropertiesOnlyFromAliasWithMaxProperties has multiple definitions of marker kubebuilder:validation:MaxProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:Maximum:=100
+	UniqueMaximum int
+
+	// +kubebuilder:validation:Maximum:=100
+	// +kubebuilder:validation:Maximum:=200
+	NonUniqueMaximum int // want "field NonUniqueMaximum has multiple definitions of marker kubebuilder:validation:Maximum when only a single definition should exist"
+
+	// +kubebuilder:validation:Maximum:=150
+	NonUniqueMaximumFromAliasWithMaximum UniqueMaximumAlias // want "field NonUniqueMaximumFromAliasWithMaximum has multiple definitions of marker kubebuilder:validation:Maximum when only a single definition should exist"
+
+	NonUniqueMaximumOnlyFromAliasWithMaximum NonUniqueMaximumAlias // want "field NonUniqueMaximumOnlyFromAliasWithMaximum has multiple definitions of marker kubebuilder:validation:Maximum when only a single definition should exist"
+
+	// +kubebuilder:validation:MinItems:=1
+	UniqueMinItems []string
+
+	// +kubebuilder:validation:MinItems:=1
+	// +kubebuilder:validation:MinItems:=2
+	NonUniqueMinItems []string // want "field NonUniqueMinItems has multiple definitions of marker kubebuilder:validation:MinItems when only a single definition should exist"
+
+	// +kubebuilder:validation:MinItems:=3
+	NonUniqueMinItemsFromAliasWithMinItems UniqueMinItemsAlias // want "field NonUniqueMinItemsFromAliasWithMinItems has multiple definitions of marker kubebuilder:validation:MinItems when only a single definition should exist"
+
+	NonUniqueMinItemsOnlyFromAliasWithMinItems NonUniqueMinItemsAlias // want "field NonUniqueMinItemsOnlyFromAliasWithMinItems has multiple definitions of marker kubebuilder:validation:MinItems when only a single definition should exist"
+
+	// +kubebuilder:validation:MinLength:=30
+	UniqueMinLengthCustom string
+
+	// +kubebuilder:validation:MinLength:=30
+	// +kubebuilder:validation:MinLength:=35
+	NonUniqueMinLengthCustom string // want "field NonUniqueMinLengthCustom has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:MinLength:=30
+	NonUniqueMinLengthCustomFromAliasWithMinLength UniqueMinLengthCustomAlias // want "field NonUniqueMinLengthCustomFromAliasWithMinLength has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	NonUniqueMinLengthCustomOnlyFromAliasWithMinLength NonUniqueMinLengthCustomAlias // want "field NonUniqueMinLengthCustomOnlyFromAliasWithMinLength has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:MinProperties:=1
+	UniqueMinPropertiesField map[string]string
+
+	// +kubebuilder:validation:MinProperties:=1
+	// +kubebuilder:validation:MinProperties:=2
+	NonUniqueMinPropertiesField map[string]string // want "field NonUniqueMinPropertiesField has multiple definitions of marker kubebuilder:validation:MinProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:MinProperties:=1
+	NonUniqueMinPropertiesFieldFromAliasWithMinProperties UniqueMinPropertiesFieldAlias // want "field NonUniqueMinPropertiesFieldFromAliasWithMinProperties has multiple definitions of marker kubebuilder:validation:MinProperties when only a single definition should exist"
+
+	NonUniqueMinPropertiesFieldOnlyFromAliasWithMinProperties NonUniqueMinPropertiesFieldAlias // want "field NonUniqueMinPropertiesFieldOnlyFromAliasWithMinProperties has multiple definitions of marker kubebuilder:validation:MinProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:Minimum:=10
+	UniqueMinimum int
+
+	// +kubebuilder:validation:Minimum:=10
+	// +kubebuilder:validation:Minimum:=20
+	NonUniqueMinimum int // want "field NonUniqueMinimum has multiple definitions of marker kubebuilder:validation:Minimum when only a single definition should exist"
+
+	// +kubebuilder:validation:Minimum:=15
+	NonUniqueMinimumFromAliasWithMinimum UniqueMinimumAlias // want "field NonUniqueMinimumFromAliasWithMinimum has multiple definitions of marker kubebuilder:validation:Minimum when only a single definition should exist"
+
+	NonUniqueMinimumOnlyFromAliasWithMinimum NonUniqueMinimumAlias // want "field NonUniqueMinimumOnlyFromAliasWithMinimum has multiple definitions of marker kubebuilder:validation:Minimum when only a single definition should exist"
+
+	// +kubebuilder:validation:MultipleOf:=3
+	UniqueMultipleOf int
+
+	// +kubebuilder:validation:MultipleOf:=3
+	// +kubebuilder:validation:MultipleOf:=5
+	NonUniqueMultipleOf int // want "field NonUniqueMultipleOf has multiple definitions of marker kubebuilder:validation:MultipleOf when only a single definition should exist"
+
+	// +kubebuilder:validation:MultipleOf:=2
+	NonUniqueMultipleOfFromAliasWithMultipleOf UniqueMultipleOfAlias // want "field NonUniqueMultipleOfFromAliasWithMultipleOf has multiple definitions of marker kubebuilder:validation:MultipleOf when only a single definition should exist"
+
+	NonUniqueMultipleOfOnlyFromAliasWithMultipleOf NonUniqueMultipleOfAlias // want "field NonUniqueMultipleOfOnlyFromAliasWithMultipleOf has multiple definitions of marker kubebuilder:validation:MultipleOf when only a single definition should exist"
+
+	// +kubebuilder:validation:Pattern:="^[a-z]+$"
+	UniquePattern string
+
+	// +kubebuilder:validation:Pattern:="^[a-z]+$"
+	// +kubebuilder:validation:Pattern:="^[0-9]+$"
+	NonUniquePattern string // want "field NonUniquePattern has multiple definitions of marker kubebuilder:validation:Pattern when only a single definition should exist"
+
+	// +kubebuilder:validation:Pattern:="^[A-Z]+$"
+	NonUniquePatternFromAliasWithPattern UniquePatternAlias // want "field NonUniquePatternFromAliasWithPattern has multiple definitions of marker kubebuilder:validation:Pattern when only a single definition should exist"
+
+	NonUniquePatternOnlyFromAliasWithPattern NonUniquePatternAlias // want "field NonUniquePatternOnlyFromAliasWithPattern has multiple definitions of marker kubebuilder:validation:Pattern when only a single definition should exist"
+
+	// +kubebuilder:validation:Type:="string"
+	UniqueTypeValidationField string
+
+	// +kubebuilder:validation:Type:="string"
+	// +kubebuilder:validation:Type:="date"
+	NonUniqueTypeValidationField string // want "field NonUniqueTypeValidationField has multiple definitions of marker kubebuilder:validation:Type when only a single definition should exist"
+
+	// +kubebuilder:validation:Type:="date"
+	NonUniqueTypeValidationFieldFromAliasWithType UniqueTypeValidationAlias // want "field NonUniqueTypeValidationFieldFromAliasWithType has multiple definitions of marker kubebuilder:validation:Type when only a single definition should exist"
+
+	NonUniqueTypeValidationFieldOnlyFromAliasWithType NonUniqueTypeValidationAlias // want "field NonUniqueTypeValidationFieldOnlyFromAliasWithType has multiple definitions of marker kubebuilder:validation:Type when only a single definition should exist"
+
+	// +kubebuilder:validation:UniqueItems:=true
+	UniqueUniqueItems []string
+
+	// +kubebuilder:validation:UniqueItems:=true
+	// +kubebuilder:validation:UniqueItems:=false
+	NonUniqueUniqueItems []string // want "field NonUniqueUniqueItems has multiple definitions of marker kubebuilder:validation:UniqueItems when only a single definition should exist"
+
+	// +kubebuilder:validation:UniqueItems:=true
+	NonUniqueUniqueItemsFromAliasWithUniqueItems UniqueUniqueItemsAlias // want "field NonUniqueUniqueItemsFromAliasWithUniqueItems has multiple definitions of marker kubebuilder:validation:UniqueItems when only a single definition should exist"
+
+	NonUniqueUniqueItemsOnlyFromAliasWithUniqueItems NonUniqueUniqueItemsAlias // want "field NonUniqueUniqueItemsOnlyFromAliasWithUniqueItems has multiple definitions of marker kubebuilder:validation:UniqueItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Enum=Apple;Orange
+	UniqueItemsEnum []string
+
+	// +kubebuilder:validation:items:Enum=Apple;Orange
+	// +kubebuilder:validation:items:Enum=Banana;Grape
+	NonUniqueItemsEnum []string // want "field NonUniqueItemsEnum has multiple definitions of marker kubebuilder:validation:items:Enum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Enum=Apple;Orange
+	NonUniqueItemsEnumFromAliasWithItemsEnum UniqueItemsEnumAlias // want "field NonUniqueItemsEnumFromAliasWithItemsEnum has multiple definitions of marker kubebuilder:validation:items:Enum when only a single definition should exist"
+
+	NonUniqueItemsEnumOnlyFromAliasWithItemsEnum NonUniqueItemsEnumAlias // want "field NonUniqueItemsEnumOnlyFromAliasWithItemsEnum has multiple definitions of marker kubebuilder:validation:items:Enum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Maximum:=10
+	// +kubebuilder:validation:items:ExclusiveMaximum:=true
+	UniqueItemsExclusiveMaximum []int
+
+	// +kubebuilder:validation:items:Maximum:=10
+	// +kubebuilder:validation:items:ExclusiveMaximum:=true
+	// +kubebuilder:validation:items:ExclusiveMaximum:=false
+	NonUniqueItemsExclusiveMaximum []int // want "field NonUniqueItemsExclusiveMaximum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMaximum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:ExclusiveMaximum:=true
+	NonUniqueItemsExclusiveMaximumFromAliasWithItemsExclusiveMaximum UniqueItemsExclusiveMaximumAlias // want "field NonUniqueItemsExclusiveMaximumFromAliasWithItemsExclusiveMaximum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMaximum when only a single definition should exist"
+
+	NonUniqueItemsExclusiveMaximumOnlyFromAliasWithItemsExclusiveMaximum NonUniqueItemsExclusiveMaximumAlias // want "field NonUniqueItemsExclusiveMaximumOnlyFromAliasWithItemsExclusiveMaximum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMaximum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Minimum:=1
+	// +kubebuilder:validation:items:ExclusiveMinimum:=true
+	UniqueItemsExclusiveMinimum []int
+
+	// +kubebuilder:validation:items:Minimum:=1
+	// +kubebuilder:validation:items:ExclusiveMinimum:=true
+	// +kubebuilder:validation:items:ExclusiveMinimum:=false
+	NonUniqueItemsExclusiveMinimum []int // want "field NonUniqueItemsExclusiveMinimum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMinimum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:ExclusiveMinimum:=true
+	NonUniqueItemsExclusiveMinimumFromAliasWithItemsExclusiveMinimum UniqueItemsExclusiveMinimumAlias // want "field NonUniqueItemsExclusiveMinimumFromAliasWithItemsExclusiveMinimum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMinimum when only a single definition should exist"
+
+	NonUniqueItemsExclusiveMinimumOnlyFromAliasWithItemsExclusiveMinimum NonUniqueItemsExclusiveMinimumAlias // want "field NonUniqueItemsExclusiveMinimumOnlyFromAliasWithItemsExclusiveMinimum has multiple definitions of marker kubebuilder:validation:items:ExclusiveMinimum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Format:="date-time"
+	UniqueItemsFormat []string
+
+	// +kubebuilder:validation:items:Format:="date-time"
+	// +kubebuilder:validation:items:Format:="password"
+	NonUniqueItemsFormat []string // want "field NonUniqueItemsFormat has multiple definitions of marker kubebuilder:validation:items:Format when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Format:="date-time"
+	NonUniqueItemsFormatFromAliasWithItemsFormat UniqueItemsFormatAlias // want "field NonUniqueItemsFormatFromAliasWithItemsFormat has multiple definitions of marker kubebuilder:validation:items:Format when only a single definition should exist"
+
+	NonUniqueItemsFormatOnlyFromAliasWithItemsFormat NonUniqueItemsFormatAlias // want "field NonUniqueItemsFormatOnlyFromAliasWithItemsFormat has multiple definitions of marker kubebuilder:validation:items:Format when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MaxItems:=5
+	UniqueItemsMaxItems [][]string
+
+	// +kubebuilder:validation:items:MaxItems:=5
+	// +kubebuilder:validation:items:MaxItems:=10
+	NonUniqueItemsMaxItems [][]string // want "field NonUniqueItemsMaxItems has multiple definitions of marker kubebuilder:validation:items:MaxItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MaxItems:=3
+	NonUniqueItemsMaxItemsFromAliasWithItemsMaxItems UniqueItemsMaxItemsAlias // want "field NonUniqueItemsMaxItemsFromAliasWithItemsMaxItems has multiple definitions of marker kubebuilder:validation:items:MaxItems when only a single definition should exist"
+
+	NonUniqueItemsMaxItemsOnlyFromAliasWithItemsMaxItems NonUniqueItemsMaxItemsAlias // want "field NonUniqueItemsMaxItemsOnlyFromAliasWithItemsMaxItems has multiple definitions of marker kubebuilder:validation:items:MaxItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MaxProperties:=3
+	UniqueItemsMaxProperties []map[string]string
+
+	// +kubebuilder:validation:items:MaxProperties:=3
+	// +kubebuilder:validation:items:MaxProperties:=5
+	NonUniqueItemsMaxProperties []map[string]string // want "field NonUniqueItemsMaxProperties has multiple definitions of marker kubebuilder:validation:items:MaxProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MaxProperties:=2
+	NonUniqueItemsMaxPropertiesFromAliasWithItemsMaxProperties UniqueItemsMaxPropertiesAlias // want "field NonUniqueItemsMaxPropertiesFromAliasWithItemsMaxProperties has multiple definitions of marker kubebuilder:validation:items:MaxProperties when only a single definition should exist"
+
+	NonUniqueItemsMaxPropertiesOnlyFromAliasWithItemsMaxProperties NonUniqueItemsMaxPropertiesAlias // want "field NonUniqueItemsMaxPropertiesOnlyFromAliasWithItemsMaxProperties has multiple definitions of marker kubebuilder:validation:items:MaxProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Maximum:=100
+	UniqueItemsMaximum []int
+
+	// +kubebuilder:validation:items:Maximum:=100
+	// +kubebuilder:validation:items:Maximum:=50
+	NonUniqueItemsMaximum []int // want "field NonUniqueItemsMaximum has multiple definitions of marker kubebuilder:validation:items:Maximum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Maximum:=75
+	NonUniqueItemsMaximumFromAliasWithItemsMaximum UniqueItemsMaximumAlias // want "field NonUniqueItemsMaximumFromAliasWithItemsMaximum has multiple definitions of marker kubebuilder:validation:items:Maximum when only a single definition should exist"
+
+	NonUniqueItemsMaximumOnlyFromAliasWithItemsMaximum NonUniqueItemsMaximumAlias // want "field NonUniqueItemsMaximumOnlyFromAliasWithItemsMaximum has multiple definitions of marker kubebuilder:validation:items:Maximum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinItems:=1
+	UniqueItemsMinItems [][]string
+
+	// +kubebuilder:validation:items:MinItems:=1
+	// +kubebuilder:validation:items:MinItems:=2
+	NonUniqueItemsMinItems [][]string // want "field NonUniqueItemsMinItems has multiple definitions of marker kubebuilder:validation:items:MinItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinItems:=3
+	NonUniqueItemsMinItemsFromAliasWithItemsMinItems UniqueItemsMinItemsAlias // want "field NonUniqueItemsMinItemsFromAliasWithItemsMinItems has multiple definitions of marker kubebuilder:validation:items:MinItems when only a single definition should exist"
+
+	NonUniqueItemsMinItemsOnlyFromAliasWithItemsMinItems NonUniqueItemsMinItemsAlias // want "field NonUniqueItemsMinItemsOnlyFromAliasWithItemsMinItems has multiple definitions of marker kubebuilder:validation:items:MinItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinLength:=5
+	UniqueItemsMinLength []string
+
+	// +kubebuilder:validation:items:MinLength:=5
+	// +kubebuilder:validation:items:MinLength:=10
+	NonUniqueItemsMinLength []string // want "field NonUniqueItemsMinLength has multiple definitions of marker kubebuilder:validation:items:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinLength:=3
+	NonUniqueItemsMinLengthFromAliasWithItemsMinLength UniqueItemsMinLengthAlias // want "field NonUniqueItemsMinLengthFromAliasWithItemsMinLength has multiple definitions of marker kubebuilder:validation:items:MinLength when only a single definition should exist"
+
+	NonUniqueItemsMinLengthOnlyFromAliasWithItemsMinLength NonUniqueItemsMinLengthAlias // want "field NonUniqueItemsMinLengthOnlyFromAliasWithItemsMinLength has multiple definitions of marker kubebuilder:validation:items:MinLength when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinProperties:=1
+	UniqueItemsMinProperties []map[string]string
+
+	// +kubebuilder:validation:items:MinProperties:=1
+	// +kubebuilder:validation:items:MinProperties:=2
+	NonUniqueItemsMinProperties []map[string]string // want "field NonUniqueItemsMinProperties has multiple definitions of marker kubebuilder:validation:items:MinProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MinProperties:=3
+	NonUniqueItemsMinPropertiesFromAliasWithItemsMinProperties UniqueItemsMinPropertiesAlias // want "field NonUniqueItemsMinPropertiesFromAliasWithItemsMinProperties has multiple definitions of marker kubebuilder:validation:items:MinProperties when only a single definition should exist"
+
+	NonUniqueItemsMinPropertiesOnlyFromAliasWithItemsMinProperties NonUniqueItemsMinPropertiesAlias // want "field NonUniqueItemsMinPropertiesOnlyFromAliasWithItemsMinProperties has multiple definitions of marker kubebuilder:validation:items:MinProperties when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Minimum:=0
+	UniqueItemsMinimum []int
+
+	// +kubebuilder:validation:items:Minimum:=0
+	// +kubebuilder:validation:items:Minimum:=-5
+	NonUniqueItemsMinimum []int // want "field NonUniqueItemsMinimum has multiple definitions of marker kubebuilder:validation:items:Minimum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Minimum:=10
+	NonUniqueItemsMinimumFromAliasWithItemsMinimum UniqueItemsMinimumAlias // want "field NonUniqueItemsMinimumFromAliasWithItemsMinimum has multiple definitions of marker kubebuilder:validation:items:Minimum when only a single definition should exist"
+
+	NonUniqueItemsMinimumOnlyFromAliasWithItemsMinimum NonUniqueItemsMinimumAlias // want "field NonUniqueItemsMinimumOnlyFromAliasWithItemsMinimum has multiple definitions of marker kubebuilder:validation:items:Minimum when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MultipleOf:=3
+	UniqueItemsMultipleOf []int
+
+	// +kubebuilder:validation:items:MultipleOf:=3
+	// +kubebuilder:validation:items:MultipleOf:=5
+	NonUniqueItemsMultipleOf []int // want "field NonUniqueItemsMultipleOf has multiple definitions of marker kubebuilder:validation:items:MultipleOf when only a single definition should exist"
+
+	// +kubebuilder:validation:items:MultipleOf:=2
+	NonUniqueItemsMultipleOfFromAliasWithItemsMultipleOf UniqueItemsMultipleOfAlias // want "field NonUniqueItemsMultipleOfFromAliasWithItemsMultipleOf has multiple definitions of marker kubebuilder:validation:items:MultipleOf when only a single definition should exist"
+
+	NonUniqueItemsMultipleOfOnlyFromAliasWithItemsMultipleOf NonUniqueItemsMultipleOfAlias // want "field NonUniqueItemsMultipleOfOnlyFromAliasWithItemsMultipleOf has multiple definitions of marker kubebuilder:validation:items:MultipleOf when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Pattern:="^[a-z]+$"
+	UniqueItemsPattern []string
+
+	// +kubebuilder:validation:items:Pattern:="^[a-z]+$"
+	// +kubebuilder:validation:items:Pattern:="^[0-9]+$"
+	NonUniqueItemsPattern []string // want "field NonUniqueItemsPattern has multiple definitions of marker kubebuilder:validation:items:Pattern when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Pattern:="^[A-Z]+$"
+	NonUniqueItemsPatternFromAliasWithItemsPattern UniqueItemsPatternAlias // want "field NonUniqueItemsPatternFromAliasWithItemsPattern has multiple definitions of marker kubebuilder:validation:items:Pattern when only a single definition should exist"
+
+	NonUniqueItemsPatternOnlyFromAliasWithItemsPattern NonUniqueItemsPatternAlias // want "field NonUniqueItemsPatternOnlyFromAliasWithItemsPattern has multiple definitions of marker kubebuilder:validation:items:Pattern when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Type:="string"
+	UniqueItemsType []string
+
+	// +kubebuilder:validation:items:Type:="string"
+	// +kubebuilder:validation:items:Type:="date"
+	NonUniqueItemsType []string // want "field NonUniqueItemsType has multiple definitions of marker kubebuilder:validation:items:Type when only a single definition should exist"
+
+	// +kubebuilder:validation:items:Type:="string"
+	NonUniqueItemsTypeFromAliasWithItemsType UniqueItemsTypeAlias // want "field NonUniqueItemsTypeFromAliasWithItemsType has multiple definitions of marker kubebuilder:validation:items:Type when only a single definition should exist"
+
+	NonUniqueItemsTypeOnlyFromAliasWithItemsType NonUniqueItemsTypeAlias // want "field NonUniqueItemsTypeOnlyFromAliasWithItemsType has multiple definitions of marker kubebuilder:validation:items:Type when only a single definition should exist"
+
+	// +kubebuilder:validation:items:UniqueItems:=true
+	UniqueItemsUniqueItems [][]string
+
+	// +kubebuilder:validation:items:UniqueItems:=true
+	// +kubebuilder:validation:items:UniqueItems:=false
+	NonUniqueItemsUniqueItems [][]string // want "field NonUniqueItemsUniqueItems has multiple definitions of marker kubebuilder:validation:items:UniqueItems when only a single definition should exist"
+
+	// +kubebuilder:validation:items:UniqueItems:=true
+	NonUniqueItemsUniqueItemsFromAliasWithItemsUniqueItems UniqueItemsUniqueItemsAlias // want "field NonUniqueItemsUniqueItemsFromAliasWithItemsUniqueItems has multiple definitions of marker kubebuilder:validation:items:UniqueItems when only a single definition should exist"
+
+	NonUniqueItemsUniqueItemsOnlyFromAliasWithItemsUniqueItems NonUniqueItemsUniqueItemsAlias // want "field NonUniqueItemsUniqueItemsOnlyFromAliasWithItemsUniqueItems has multiple definitions of marker kubebuilder:validation:items:UniqueItems when only a single definition should exist"
+}
+
+// +default:value="bart"
+type UniqueBasicDefaultAlias string
+
+// +default:value="homer"
+// +default:value="bart"
+type NonUniqueBasicDefaultAlias string // want "type NonUniqueBasicDefaultAlias has multiple definitions of marker default when only a single definition should exist"
+
+// +kubebuilder:default:="bart"
+type UniqueKubebuilderDefaultAlias string
+
+// +kubebuilder:default:="homer"
+// +kubebuilder:default:="bart"
+type NonUniqueKubebuilderDefaultAlias string // want "type NonUniqueKubebuilderDefaultAlias has multiple definitions of marker kubebuilder:default when only a single definition should exist"
+
+// +kubebuilder:example:="bart"
+type UniqueKubebuilderExampleAlias string
+
+// +kubebuilder:example:="homer"
+// +kubebuilder:example:="bart"
+type NonUniqueKubebuilderExampleAlias string // want "type NonUniqueKubebuilderExampleAlias has multiple definitions of marker kubebuilder:example when only a single definition should exist"
+
+// +kubebuilder:validation:MinLength:=5
+type UniqueMinLengthStringAlias string
+
+// +kubebuilder:validation:MinLength:=5
+// +kubebuilder:validation:MinLength:=1
+type NonUniqueMinLengthStringAlias string // want "type NonUniqueMinLengthStringAlias has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+// +kubebuilder:validation:Enum:=Baz;Qux
+type UniqueEnumAlias string
+
+// +kubebuilder:validation:Enum:=Foo;Bar
+// +kubebuilder:validation:Enum=Baz;Qux
+type NonUniqueEnumAlias string // want "type NonUniqueEnumAlias has multiple definitions of marker kubebuilder:validation:Enum when only a single definition should exist"
+
+// +kubebuilder:validation:Maximum:=5
+// +kubebuilder:validation:ExclusiveMaximum:=false
+type UniqueExclusiveMaximumAlias int
+
+// +kubebuilder:validation:Maximum:=5
+// +kubebuilder:validation:ExclusiveMaximum:=true
+// +kubebuilder:validation:ExclusiveMaximum:=false
+type NonUniqueExclusiveMaximumAlias int // want "type NonUniqueExclusiveMaximumAlias has multiple definitions of marker kubebuilder:validation:ExclusiveMaximum when only a single definition should exist"
+
+// +kubebuilder:validation:Minimum:=2
+// +kubebuilder:validation:ExclusiveMinimum:=false
+type UniqueExclusiveMinimumAlias int
+
+// +kubebuilder:validation:Minimum:=2
+// +kubebuilder:validation:ExclusiveMinimum:=true
+// +kubebuilder:validation:ExclusiveMinimum:=false
+type NonUniqueExclusiveMinimumAlias int // want "type NonUniqueExclusiveMinimumAlias has multiple definitions of marker kubebuilder:validation:ExclusiveMinimum when only a single definition should exist"
+
+// +kubebuilder:validation:Format:="date"
+type UniqueFormatAlias string
+
+// +kubebuilder:validation:Format:="date"
+// +kubebuilder:validation:Format:="password"
+type NonUniqueFormatAlias string // want "type NonUniqueFormatAlias has multiple definitions of marker kubebuilder:validation:Format when only a single definition should exist"
+
+// +kubebuilder:validation:MaxItems:=3
+type UniqueMaxItemsAlias []string
+
+// +kubebuilder:validation:MaxItems:=3
+// +kubebuilder:validation:MaxItems:=7
+type NonUniqueMaxItemsAlias []string // want "type NonUniqueMaxItemsAlias has multiple definitions of marker kubebuilder:validation:MaxItems when only a single definition should exist"
+
+// +kubebuilder:validation:MaxProperties:=2
+type UniqueMaxPropertiesAlias map[string]string
+
+// +kubebuilder:validation:MaxProperties:=2
+// +kubebuilder:validation:MaxProperties:=6
+type NonUniqueMaxPropertiesAlias map[string]string // want "type NonUniqueMaxPropertiesAlias has multiple definitions of marker kubebuilder:validation:MaxProperties when only a single definition should exist"
+
+// +kubebuilder:validation:Maximum:=50
+type UniqueMaximumAlias int
+
+// +kubebuilder:validation:Maximum:=50
+// +kubebuilder:validation:Maximum:=75
+type NonUniqueMaximumAlias int // want "type NonUniqueMaximumAlias has multiple definitions of marker kubebuilder:validation:Maximum when only a single definition should exist"
+
+// +kubebuilder:validation:MinItems:=4
+type UniqueMinItemsAlias []string
+
+// +kubebuilder:validation:MinItems:=4
+// +kubebuilder:validation:MinItems:=5
+type NonUniqueMinItemsAlias []string // want "type NonUniqueMinItemsAlias has multiple definitions of marker kubebuilder:validation:MinItems when only a single definition should exist"
+
+// +kubebuilder:validation:MinLength:=40
+type UniqueMinLengthCustomAlias string
+
+// +kubebuilder:validation:MinLength:=40
+// +kubebuilder:validation:MinLength:=45
+type NonUniqueMinLengthCustomAlias string // want "type NonUniqueMinLengthCustomAlias has multiple definitions of marker kubebuilder:validation:MinLength when only a single definition should exist"
+
+// +kubebuilder:validation:MinProperties:=4
+type UniqueMinPropertiesFieldAlias map[string]string
+
+// +kubebuilder:validation:MinProperties:=4
+// +kubebuilder:validation:MinProperties:=5
+type NonUniqueMinPropertiesFieldAlias map[string]string // want "type NonUniqueMinPropertiesFieldAlias has multiple definitions of marker kubebuilder:validation:MinProperties when only a single definition should exist"
+
+// +kubebuilder:validation:Minimum:=5
+type UniqueMinimumAlias int
+
+// +kubebuilder:validation:Minimum:=5
+// +kubebuilder:validation:Minimum:=7
+type NonUniqueMinimumAlias int // want "type NonUniqueMinimumAlias has multiple definitions of marker kubebuilder:validation:Minimum when only a single definition should exist"
+
+// +kubebuilder:validation:MultipleOf:=7
+type UniqueMultipleOfAlias int
+
+// +kubebuilder:validation:MultipleOf:=7
+// +kubebuilder:validation:MultipleOf:=11
+type NonUniqueMultipleOfAlias int // want "type NonUniqueMultipleOfAlias has multiple definitions of marker kubebuilder:validation:MultipleOf when only a single definition should exist"
+
+// +kubebuilder:validation:Pattern:="^\\w+$"
+type UniquePatternAlias string
+
+// +kubebuilder:validation:Pattern:="^\\w+$"
+// +kubebuilder:validation:Pattern:="^\\d+$"
+type NonUniquePatternAlias string // want "type NonUniquePatternAlias has multiple definitions of marker kubebuilder:validation:Pattern when only a single definition should exist"
+
+// +kubebuilder:validation:Type:="string"
+type UniqueTypeValidationAlias string
+
+// +kubebuilder:validation:Type:="string"
+// +kubebuilder:validation:Type:="date"
+type NonUniqueTypeValidationAlias string // want "type NonUniqueTypeValidationAlias has multiple definitions of marker kubebuilder:validation:Type when only a single definition should exist"
+
+// +kubebuilder:validation:UniqueItems:=false
+type UniqueUniqueItemsAlias []string
+
+// +kubebuilder:validation:UniqueItems:=true
+// +kubebuilder:validation:UniqueItems:=false
+type NonUniqueUniqueItemsAlias []string // want "type NonUniqueUniqueItemsAlias has multiple definitions of marker kubebuilder:validation:UniqueItems when only a single definition should exist"
+
+// +kubebuilder:validation:items:Enum=Banana;Grape
+type UniqueItemsEnumAlias []string
+
+// +kubebuilder:validation:items:Enum=Apple;Orange
+// +kubebuilder:validation:items:Enum=Banana;Grape
+type NonUniqueItemsEnumAlias []string // want "type NonUniqueItemsEnumAlias has multiple definitions of marker kubebuilder:validation:items:Enum when only a single definition should exist"
+
+// +kubebuilder:validation:items:Maximum:=5
+// +kubebuilder:validation:items:ExclusiveMaximum:=false
+type UniqueItemsExclusiveMaximumAlias []int
+
+// +kubebuilder:validation:items:Maximum:=5
+// +kubebuilder:validation:items:ExclusiveMaximum:=true
+// +kubebuilder:validation:items:ExclusiveMaximum:=false
+type NonUniqueItemsExclusiveMaximumAlias []int // want "type NonUniqueItemsExclusiveMaximumAlias has multiple definitions of marker kubebuilder:validation:items:ExclusiveMaximum when only a single definition should exist"
+
+// +kubebuilder:validation:items:Minimum:=2
+// +kubebuilder:validation:items:ExclusiveMinimum:=false
+type UniqueItemsExclusiveMinimumAlias []int
+
+// +kubebuilder:validation:items:Minimum:=2
+// +kubebuilder:validation:items:ExclusiveMinimum:=true
+// +kubebuilder:validation:items:ExclusiveMinimum:=false
+type NonUniqueItemsExclusiveMinimumAlias []int // want "type NonUniqueItemsExclusiveMinimumAlias has multiple definitions of marker kubebuilder:validation:items:ExclusiveMinimum when only a single definition should exist"
+
+// +kubebuilder:validation:items:Format:="password"
+type UniqueItemsFormatAlias []string
+
+// +kubebuilder:validation:items:Format:="date-time"
+// +kubebuilder:validation:items:Format:="password"
+type NonUniqueItemsFormatAlias []string // want "type NonUniqueItemsFormatAlias has multiple definitions of marker kubebuilder:validation:items:Format when only a single definition should exist"
+
+// +kubebuilder:validation:items:MaxItems:=2
+type UniqueItemsMaxItemsAlias [][]string
+
+// +kubebuilder:validation:items:MaxItems:=2
+// +kubebuilder:validation:items:MaxItems:=4
+type NonUniqueItemsMaxItemsAlias [][]string // want "type NonUniqueItemsMaxItemsAlias has multiple definitions of marker kubebuilder:validation:items:MaxItems when only a single definition should exist"
+
+// +kubebuilder:validation:items:MaxProperties:=1
+type UniqueItemsMaxPropertiesAlias []map[string]string
+
+// +kubebuilder:validation:items:MaxProperties:=1
+// +kubebuilder:validation:items:MaxProperties:=4
+type NonUniqueItemsMaxPropertiesAlias []map[string]string // want "type NonUniqueItemsMaxPropertiesAlias has multiple definitions of marker kubebuilder:validation:items:MaxProperties when only a single definition should exist"
+
+// kubebuilder:validation:items:Maximum
+// +kubebuilder:validation:items:Maximum:=25
+type UniqueItemsMaximumAlias []int
+
+// +kubebuilder:validation:items:Maximum:=25
+// +kubebuilder:validation:items:Maximum:=10
+type NonUniqueItemsMaximumAlias []int // want "type NonUniqueItemsMaximumAlias has multiple definitions of marker kubebuilder:validation:items:Maximum when only a single definition should exist"
+
+// +kubebuilder:validation:items:MinItems:=4
+type UniqueItemsMinItemsAlias [][]string
+
+// +kubebuilder:validation:items:MinItems:=4
+// +kubebuilder:validation:items:MinItems:=2
+type NonUniqueItemsMinItemsAlias [][]string // want "type NonUniqueItemsMinItemsAlias has multiple definitions of marker kubebuilder:validation:items:MinItems when only a single definition should exist"
+
+// +kubebuilder:validation:items:MinLength:=8
+type UniqueItemsMinLengthAlias []string
+
+// +kubebuilder:validation:items:MinLength:=8
+// +kubebuilder:validation:items:MinLength:=2
+type NonUniqueItemsMinLengthAlias []string // want "type NonUniqueItemsMinLengthAlias has multiple definitions of marker kubebuilder:validation:items:MinLength when only a single definition should exist"
+
+// +kubebuilder:validation:items:MinProperties:=4
+type UniqueItemsMinPropertiesAlias []map[string]string
+
+// +kubebuilder:validation:items:MinProperties:=4
+// +kubebuilder:validation:items:MinProperties:=2
+type NonUniqueItemsMinPropertiesAlias []map[string]string // want "type NonUniqueItemsMinPropertiesAlias has multiple definitions of marker kubebuilder:validation:items:MinProperties when only a single definition should exist"
+
+// +kubebuilder:validation:items:Minimum:=20
+type UniqueItemsMinimumAlias []int
+
+// +kubebuilder:validation:items:Minimum:=20
+// +kubebuilder:validation:items:Minimum:=30
+type NonUniqueItemsMinimumAlias []int // want "type NonUniqueItemsMinimumAlias has multiple definitions of marker kubebuilder:validation:items:Minimum when only a single definition should exist"
+
+// +kubebuilder:validation:items:MultipleOf:=7
+type UniqueItemsMultipleOfAlias []int
+
+// +kubebuilder:validation:items:MultipleOf:=7
+// +kubebuilder:validation:items:MultipleOf:=11
+type NonUniqueItemsMultipleOfAlias []int // want "type NonUniqueItemsMultipleOfAlias has multiple definitions of marker kubebuilder:validation:items:MultipleOf when only a single definition should exist"
+
+// kubebuilder:validation:items:Pattern
+// +kubebuilder:validation:items:Pattern:="^\\w+$"
+type UniqueItemsPatternAlias []string
+
+// +kubebuilder:validation:items:Pattern:="^\\w+$"
+// +kubebuilder:validation:items:Pattern:="^\\d+$"
+type NonUniqueItemsPatternAlias []string // want "type NonUniqueItemsPatternAlias has multiple definitions of marker kubebuilder:validation:items:Pattern when only a single definition should exist"
+
+// +kubebuilder:validation:items:Type:="date"
+type UniqueItemsTypeAlias []string
+
+// +kubebuilder:validation:items:Type:="string"
+// +kubebuilder:validation:items:Type:="date"
+type NonUniqueItemsTypeAlias []string // want "type NonUniqueItemsTypeAlias has multiple definitions of marker kubebuilder:validation:items:Type when only a single definition should exist"
+
+// +kubebuilder:validation:items:UniqueItems:=false
+type UniqueItemsUniqueItemsAlias [][]string
+
+// +kubebuilder:validation:items:UniqueItems:=true
+// +kubebuilder:validation:items:UniqueItems:=false
+type NonUniqueItemsUniqueItemsAlias [][]string // want "type NonUniqueItemsUniqueItemsAlias has multiple definitions of marker kubebuilder:validation:items:UniqueItems when only a single definition should exist"

--- a/pkg/analysis/uniquemarkers/testdata/src/b/b.go
+++ b/pkg/analysis/uniquemarkers/testdata/src/b/b.go
@@ -1,0 +1,71 @@
+package b
+
+type B struct {
+	// +custom:SomeCustomMarker:=value
+	UniqueCustomMarker string
+
+	// +custom:SomeCustomMarker:=value
+	// +custom:SomeCustomMarker:=diffvalue
+	NonUniqueCustomMarker string // want "field NonUniqueCustomMarker has multiple definitions of marker custom:SomeCustomMarker when only a single definition should exist"
+
+	// +custom:SomeCustomMarker:=value
+	NonUniqueCustomMarkerFromAliasWithCustomMarker UniqueCustomMarkerAlias // want "field NonUniqueCustomMarkerFromAliasWithCustomMarker has multiple definitions of marker custom:SomeCustomMarker when only a single definition should exist"
+
+	NonUniqueCustomMarkerOnlyFromAliasWithCustomMarker NonUniqueCustomMarkerAlias // want "field NonUniqueCustomMarkerOnlyFromAliasWithCustomMarker has multiple definitions of marker custom:SomeCustomMarker when only a single definition should exist"
+
+	// +custom:SomeCustomMarker:=value
+	// +custom:SomeCustomMarker:=value
+	NonUniqueSameValueCustomMarker string // want "field NonUniqueSameValueCustomMarker has multiple definitions of marker custom:SomeCustomMarker when only a single definition should exist"
+
+	// +custom:OtherMarker:attribute=apple,otherAttribute=orange
+	UniqueCustomMarkerWithAttribute string
+
+	// +custom:OtherMarker:attribute=apple,otherAttribute=orange
+	// +custom:OtherMarker:attribute=apple,otherAttribute=banana
+	NonUniqueCustomMarkerWithAttribute string // want "field NonUniqueCustomMarkerWithAttribute has multiple definitions of marker custom:OtherMarker:attribute=apple when only a single definition should exist"
+
+	// +custom:OtherMarker:attribute=apple,otherAttribute=orange
+	NonUniqueCustomMarkerWithAttributeFromAliasWithCustomMarkerWithAttribute UniqueCustomMarkerWithAttributeAlias // want "field NonUniqueCustomMarkerWithAttributeFromAliasWithCustomMarkerWithAttribute has multiple definitions of marker custom:OtherMarker:attribute=apple when only a single definition should exist"
+
+	NonUniqueCustomMarkerWithAttributeOnlyFromAliasWithCustomMarkerWithAttribute NonUniqueCustomMarkerWithAttributeAlias // want "field NonUniqueCustomMarkerWithAttributeOnlyFromAliasWithCustomMarkerWithAttribute has multiple definitions of marker custom:OtherMarker:attribute=apple when only a single definition should exist"
+
+	// +custom:OtherMarker:attribute=apple,otherAttribute=orange
+	// +custom:OtherMarker:attribute=orange,otherAttribute=apple
+	MultipleUniqueCustomMarkerWithAttribute string
+	
+	// +custom:MultiMarker:fruit=apple,color=blue,country='US'
+	// +custom:MultiMarker:fruit=apple,color=blue,country='UK'
+	// +custom:MultiMarker:fruit=apple,color=green,country='US'
+	// +custom:MultiMarker:fruit=orange,color=blue,country='US'
+	// +custom:MultiMarker:fruit=orange,color=blue,country='UK'
+	// +custom:MultiMarker:fruit=orange,color=green,country='US'
+	UniqueMultiAttributeMarker string
+
+	// +custom:MultiMarker:fruit=apple,color=blue,country='US',state="NY"
+	// +custom:MultiMarker:fruit=apple,color=blue,country='US',state="NC"
+	NonUniqueMultiAttributeMarker string // want "field NonUniqueMultiAttributeMarker has multiple definitions of marker custom:MultiMarker:fruit=apple,color=blue,country='US' when only a single definition should exist"
+
+	// +custom:MultiMarker:fruit=apple,color=blue
+	// +custom:MultiMarker:fruit=apple,color=blue,country="UK"
+	// +custom:MultiMarker:fruit=apple,country="UK"
+	// +custom:MultiMarker:color=blue,country="UK"
+	UniqueMultiAttributeMarkerFromMissingAttribute string
+
+	// +custom:MultiMarker:fruit=apple,color=blue
+	// +custom:MultiMarker:fruit=apple,color=blue
+	NonUniqueMultiAttributeMarkerFromMissingAttribute string // want "field NonUniqueMultiAttributeMarkerFromMissingAttribute has multiple definitions of marker custom:MultiMarker:fruit=apple,color=blue,country= when only a single definition should exist"
+}
+
+// +custom:SomeCustomMarker:=diffvalue
+type UniqueCustomMarkerAlias string
+
+// +custom:SomeCustomMarker:=value
+// +custom:SomeCustomMarker:=diffvalue
+type NonUniqueCustomMarkerAlias string // want "type NonUniqueCustomMarkerAlias has multiple definitions of marker custom:SomeCustomMarker when only a single definition should exist"
+
+// +custom:OtherMarker:attribute=apple,otherAttribute=banana
+type UniqueCustomMarkerWithAttributeAlias string
+
+// +custom:OtherMarker:attribute=apple,otherAttribute=orange
+// +custom:OtherMarker:attribute=apple,otherAttribute=banana
+type NonUniqueCustomMarkerWithAttributeAlias string // want "type NonUniqueCustomMarkerWithAttributeAlias has multiple definitions of marker custom:OtherMarker:attribute=apple when only a single definition should exist"

--- a/pkg/config/linters_config.go
+++ b/pkg/config/linters_config.go
@@ -37,6 +37,9 @@ type LintersConfig struct {
 
 	// statusOptional contains configuration for the statusoptional linter.
 	StatusOptional StatusOptionalConfig `json:"statusOptional"`
+
+	// uniqueMarkers contains configuration for the uniquemarkers linter.
+	UniqueMarkers UniqueMarkersConfig `json:"uniqueMarkers"`
 }
 
 // ConditionsFirstField is the policy for the conditions linter.
@@ -263,4 +266,30 @@ type StatusOptionalConfig struct {
 	// If this field is not set, the default value is "optional".
 	// Valid values are "optional", "kubebuilder:validation:Optional" and "k8s:optional".
 	PreferredOptionalMarker string `json:"preferredOptionalMarker"`
+}
+
+// UniqueMarkersConfig contains the configuration for the uniquemarkers linter.
+type UniqueMarkersConfig struct {
+	// customMarkers is the set of custom marker/attribute combinations that
+	// should not appear more than once on a type/field.
+	// Entries must have unique identifiers.
+	// Entries must start and end with alpha characters and must consist of only alpha characters and colons (':').
+	CustomMarkers []UniqueMarker `json:"customMarkers"`
+}
+
+// UniqueMarker represents an instance of a marker that should
+// be unique for a field/type. A marker consists
+// of an identifier and attributes that can be used
+// to dictate uniqueness.
+type UniqueMarker struct {
+	// identifier configures the marker identifier that should be unique.
+	// Some common examples are "kubebuilder:validation:Enum" and "kubebuilder:validation:XValidation".
+	Identifier string `json:"identifier"`
+	// attributes configures the attributes that should be considered
+	// as part of the uniqueness evaluation.
+	// If an attribute in this list is not found in a marker definition,
+	// it is interpreted as the empty value.
+	//
+	// Entries must be unique.
+	Attributes []string `json:"attributes"`
 }

--- a/pkg/markers/markers.go
+++ b/pkg/markers/markers.go
@@ -24,6 +24,9 @@ const (
 
 	// NullableMarker is the marker that indicates that a field can be null.
 	NullableMarker = "nullable"
+
+	// DefaultMarker is the marker that specifies the default value of a field or type.
+	DefaultMarker = "default"
 )
 
 const (
@@ -48,6 +51,9 @@ const (
 	// KubebuilderMaxLengthMarker is the marker that indicates that a field has a maximum length in kubebuilder.
 	KubebuilderMaxLengthMarker = "kubebuilder:validation:MaxLength"
 
+	// KubebuilderMaxPropertiesMarker is the marker that indicates that a field has a maximum number of properties in kubebuilder.
+	KubebuilderMaxPropertiesMarker = "kubebuilder:validation:MaxProperties"
+
 	// KubebuilderMinimumMarker is the marker that indicates that a field has a minimum value in kubebuilder.
 	KubebuilderMinimumMarker = "kubebuilder:validation:Minimum"
 
@@ -59,6 +65,27 @@ const (
 
 	// KubebuilderMinPropertiesMarker is the marker that indicates that a field has a minimum number of properties in kubebuilder.
 	KubebuilderMinPropertiesMarker = "kubebuilder:validation:MinProperties"
+
+	// KubebuilderItemsMaxItemsMarker is the marker that indicates that a nested array field has a maximum number of items in kubebuilder.
+	KubebuilderItemsMaxItemsMarker = "kubebuilder:validation:items:MaxItems"
+
+	// KubebuilderItemsMaxPropertiesMarker is the marker that indicates that array items have a maximum number of properties in kubebuilder.
+	KubebuilderItemsMaxPropertiesMarker = "kubebuilder:validation:items:MaxProperties"
+
+	// KubebuilderItemsMaximumMarker is the marker that indicates that array items have a maximum in kubebuilder.
+	KubebuilderItemsMaximumMarker = "kubebuilder:validation:items:Maximum"
+
+	// KubebuilderItemsMinItemsMarker is the marker that indicates that a nested array field has a minimum number of items in kubebuilder.
+	KubebuilderItemsMinItemsMarker = "kubebuilder:validation:items:MinItems"
+
+	// KubebuilderItemsMinLengthMarker is the marker that indicates that array items have a minimum length in kubebuilder.
+	KubebuilderItemsMinLengthMarker = "kubebuilder:validation:items:MinLength"
+
+	// KubebuilderItemsMinPropertiesMarker is the marker that indicates that array items have a minimum number of properties in kubebuilder.
+	KubebuilderItemsMinPropertiesMarker = "kubebuilder:validation:items:MinProperties"
+
+	// KubebuilderItemsMinimumMarker is the marker that indicates that array items have a minimum in kubebuilder.
+	KubebuilderItemsMinimumMarker = "kubebuilder:validation:items:Minimum"
 
 	// KubebuilderOptionalMarker is the marker that indicates that a field is optional in kubebuilder.
 	KubebuilderOptionalMarker = "kubebuilder:validation:Optional"
@@ -74,6 +101,54 @@ const (
 
 	// KubebuilderItemsFormatMarker is the marker that indicates that a field has a format in kubebuilder.
 	KubebuilderItemsFormatMarker = "kubebuilder:validation:items:Format"
+
+	// KubebuilderDefaultMarker is the marker used to specify the default value for a type or field in kubebuilder.
+	KubebuilderDefaultMarker = "kubebuilder:default"
+
+	// KubebuilderExampleMarker is the marker used to specify an example value for the type or field in kubebuilder.
+	KubebuilderExampleMarker = "kubebuilder:example"
+
+	// KubebuilderExclusiveMaximumMarker is the marker used to specify that the maximum value is excluded from the allowed values (i.e "up to, but not including") for a type or field in kubebuilder.
+	KubebuilderExclusiveMaximumMarker = "kubebuilder:validation:ExclusiveMaximum"
+
+	// KubebuilderExclusiveMinimumMarker is the marker used to specify that the minimum value is excluded from the allowed values (i.e "up to, but not including") for a type or field in kubebuilder.
+	KubebuilderExclusiveMinimumMarker = "kubebuilder:validation:ExclusiveMinimum"
+
+	// KubebuilderMultipleOfMarker is the marker used to specify that the value for a type or field must be a multiple of X in kubebuilder.
+	KubebuilderMultipleOfMarker = "kubebuilder:validation:MultipleOf"
+
+	// KubebuilderPatternMarker is the marker used to specify that the value for a type or field must follow a particular regex pattern in kubebuilder.
+	KubebuilderPatternMarker = "kubebuilder:validation:Pattern"
+
+	// KubebuilderTypeMarker is the marker used to specify the type a value should be for a type or field in kubebuilder.
+	KubebuilderTypeMarker = "kubebuilder:validation:Type"
+
+	// KubebuilderUniqueItemsMarker is the marker used to specify that a type or field must contain unique items in kubebuilder.
+	KubebuilderUniqueItemsMarker = "kubebuilder:validation:UniqueItems"
+
+	// KubebuilderItemsExclusiveMaximumMarker is the marker used to specify that the maximum value for an array item is excluded from the allowed values (i.e "up to, but not including") for a type or field in kubebuilder.
+	KubebuilderItemsExclusiveMaximumMarker = "kubebuilder:validation:items:ExclusiveMaximum"
+
+	// KubebuilderItemsExclusiveMinimumMarker is the marker used to specify that the minimum value for an array item is excluded from the allowed values (i.e "up to, but not including") for a type or field in kubebuilder.
+	KubebuilderItemsExclusiveMinimumMarker = "kubebuilder:validation:items:ExclusiveMinimum"
+
+	// KubebuilderItemsMultipleOfMarker is the marker used to specify that the value of an array item for the type or field must be a multiple of X in kubebuilder.
+	KubebuilderItemsMultipleOfMarker = "kubebuilder:validation:items:MultipleOf"
+
+	// KubebuilderItemsPatternMarker is the marker used to specify that the value of an array item for the type or field must follow a particular regex pattern in kubebuilder.
+	KubebuilderItemsPatternMarker = "kubebuilder:validation:items:Pattern"
+
+	// KubebuilderItemsTypeMarker is the marker used to specify the type an array item should be for the type or field in kubebuilder.
+	KubebuilderItemsTypeMarker = "kubebuilder:validation:items:Type"
+
+	// KubebuilderItemsUniqueItemsMarker is the marker used to specify that entries to a nested array type or field must contain unique items in kubebuilder.
+	KubebuilderItemsUniqueItemsMarker = "kubebuilder:validation:items:UniqueItems"
+
+	// KubebuilderXValidationMarker is the marker used to specify CEL validation rules for a type or field in kubebuilder.
+	KubebuilderXValidationMarker = "kubebuilder:validation:XValidation"
+
+	// KubebuilderItemsXValidationMarker is the marker used to specify CEL validation rules for entries to a nested array type or field in kubebuilder.
+	KubebuilderItemsXValidationMarker = "kubebuilder:validation:items:XValidation"
 )
 
 const (


### PR DESCRIPTION
Adds a new `uniquemarkers` linter that checks for more than a single instance of all kubebuilder markers that should be unique.

The linter can be configured to also check for a custom set of markers that should also be considered unique.

Fixes #83