### PR TITLE
Add notimestamp linter

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -10,6 +10,7 @@
 - [NoFloats](#nofloats) - Prevents usage of floating-point types
 - [Nomaps](#nomaps) - Restricts usage of map types
 - [Nophase](#nophase) - Prevents usage of 'Phase' fields
+- [Notimestamp](#notimestamp) - Prevents usage of 'TimeStamp' fields
 - [OptionalFields](#optionalfields) - Validates optional field conventions
 - [OptionalOrRequired](#optionalorrequired) - Ensures fields are explicitly marked as optional or required
 - [RequiredFields](#requiredfields) - Validates required field conventions
@@ -159,6 +160,19 @@ lintersConfig:
   nomaps:
     policy: Enforce | AllowStringToStringMaps | Ignore # Determines how the linter should handle maps of simple types. Defaults to AllowStringToStringMaps.
 ```
+
+## Notimestamp
+
+The `notimestamp` linter checks that the fields in the API are not named with the word 'Timestamp'.
+
+The name of a field that specifies the time at which something occurs should be called `somethingTime`. It is recommended not use 'stamp' (e.g., creationTimestamp).
+
+### Fixes
+
+The `notimestamp` linter will automatically fix fields and json tags that are named with the word 'Timestamp'.
+
+It will automatically replace 'Timestamp' with 'Time' and update both the field and tag name.
+Example: 'FooTimestamp' will be updated to 'FooTime'.
 
 ## Nophase
 

--- a/pkg/analysis/notimestamp/analyzer.go
+++ b/pkg/analysis/notimestamp/analyzer.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notimestamp
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+)
+
+const name = "notimestamp"
+
+// Analyzer is the analyzer for the notimestamp package.
+// It checks that no struct fields named 'timestamp', or that contain timestamp as a
+// substring are present.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "Suggest the usage of the term 'time' over 'timestamp'",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspector.Analyzer},
+}
+
+// case-insensitive regular expression to match 'timestamp' string in field or json tag.
+var timeStampRegEx = regexp.MustCompile("(?i)timestamp")
+
+func run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
+		checkFieldsAndTags(pass, field, jsonTagInfo)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkFieldsAndTags(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo) {
+	fieldName := utils.FieldName(field)
+	if fieldName == "" {
+		return
+	}
+
+	var suggestedFixes []analysis.SuggestedFix
+
+	// check if filed name contains timestamp in it.
+	fieldReplacementName := timeStampRegEx.ReplaceAllString(fieldName, "Time")
+	if fieldReplacementName != fieldName {
+		suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+			Message: fmt.Sprintf("replace %s with %s", fieldName, fieldReplacementName),
+			TextEdits: []analysis.TextEdit{
+				{
+					Pos:     field.Pos(),
+					NewText: []byte(fieldReplacementName),
+					End:     field.Pos() + token.Pos(len(fieldName)),
+				},
+			},
+		})
+	}
+
+	// check if the tag contains timestamp in it.
+	tagReplacementName := timeStampRegEx.ReplaceAllString(tagInfo.Name, "Time")
+	if strings.HasPrefix(strings.ToLower(tagInfo.Name), "time") {
+		// If the tag starts with 'timeStamp', the replacement should be 'time' not 'Time'.
+		tagReplacementName = timeStampRegEx.ReplaceAllString(tagInfo.Name, "time")
+	}
+
+	if tagReplacementName != tagInfo.Name {
+		suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+			Message: fmt.Sprintf("replace %s json tag with %s", tagInfo.Name, tagReplacementName),
+			TextEdits: []analysis.TextEdit{
+				{
+					Pos:     tagInfo.Pos,
+					NewText: []byte(tagReplacementName),
+					End:     tagInfo.Pos + token.Pos(len(tagInfo.Name)),
+				},
+			},
+		})
+	}
+
+	if len(suggestedFixes) > 0 {
+		pass.Report(analysis.Diagnostic{
+			Pos:            field.Pos(),
+			Message:        fmt.Sprintf("field %s: prefer use of the term time over timestamp", fieldName),
+			SuggestedFixes: suggestedFixes,
+		})
+	}
+}

--- a/pkg/analysis/notimestamp/analyzer_test.go
+++ b/pkg/analysis/notimestamp/analyzer_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notimestamp_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, notimestamp.Analyzer, "a")
+}

--- a/pkg/analysis/notimestamp/doc.go
+++ b/pkg/analysis/notimestamp/doc.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+notimestamp provides a linter to ensure that structs do not contain a TimeStamp field.
+
+The linter will flag any struct field containing the substring 'timestamp'. This means both
+TimeStamp and FooTimeStamp will be flagged.
+*/
+
+package notimestamp

--- a/pkg/analysis/notimestamp/initializer.go
+++ b/pkg/analysis/notimestamp/initializer.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notimestamp
+
+import (
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewInitializer(
+		name,
+		Analyzer,
+		true,
+	)
+}

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go
@@ -1,0 +1,46 @@
+package a
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type NoTimeStampTestStruct struct {
+	// +optional
+	TimeStamp *time.Time `json:"timeStamp,omitempty"` // want "field TimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	Timestamp *time.Time `json:"timestamp,omitempty"` // want "field Timestamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FootimeStamp *time.Time `json:"footimeStamp,omitempty"` // want "field FootimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	BarTimestamp *time.Time `json:"barTimestamp,omitempty"` // want "field BarTimestamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FootimestampBar *time.Time `json:"fooTimestampBar,omitempty"` // want "field FootimestampBar: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTimestampBarTimeStamp *time.Time `json:"fooTimestampBarTimeStamp,omitempty"` // want "field FooTimestampBarTimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	MetaTimeStamp *metav1.Time `json:"metaTimeStamp,omitempty"` // want "field MetaTimeStamp: prefer use of the term time over timestamp"
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (NoTimeStampTestStruct) DoNothing() {}
+
+type NoSubTimeStampTestStruct struct {
+	// +optional
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+}
+
+type SerializedTimeStampTestStruct struct {
+	// +optional
+	FooTime *time.Time `json:"fooTime,omitempty"`
+}

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
@@ -1,0 +1,46 @@
+package a
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type NoTimeStampTestStruct struct {
+	// +optional
+	Time *time.Time `json:"time,omitempty"` // want "field TimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	Time *time.Time `json:"time,omitempty"` // want "field Timestamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FootimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	BarTime *time.Time `json:"barTime,omitempty"` // want "field BarTimestamp: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTimeBar *time.Time `json:"fooTimeBar,omitempty"` // want "field FootimestampBar: prefer use of the term time over timestamp"
+
+	// +optional
+	FooTimeBarTime *time.Time `json:"fooTimeBarTime,omitempty"` // want "field FooTimestampBarTimeStamp: prefer use of the term time over timestamp"
+
+	// +optional
+	MetaTime *metav1.Time `json:"metaTime,omitempty"` // want "field MetaTimeStamp: prefer use of the term time over timestamp"
+}
+
+// DoNothing is used to check that the analyser doesn't report on methods.
+func (NoTimeStampTestStruct) DoNothing() {}
+
+type NoSubTimeStampTestStruct struct {
+	// +optional
+	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+}
+
+type SerializedTimeStampTestStruct struct {
+	// +optional
+	FooTime *time.Time `json:"fooTime,omitempty"`
+}

--- a/pkg/analysis/notimestamp/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/pkg/analysis/notimestamp/testdata/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1,0 +1,92 @@
+/*
+This is a copy of the minimum amount of the original file to be able to test the conditions linter.
+*/
+package v1
+
+import "time"
+
+// Time is a wrapper around time.Time which supports correct
+// marshaling to YAML and JSON.  Wrappers are provided for many
+// of the factory methods that the time package offers.
+//
+// +protobuf.options.marshal=false
+// +protobuf.as=Timestamp
+// +protobuf.options.(gogoproto.goproto_stringer)=false
+type Time struct {
+	time.Time `protobuf:"-"`
+}
+
+type ConditionStatus string
+
+// These are valid condition statuses. "ConditionTrue" means a resource is in the condition.
+// "ConditionFalse" means a resource is not in the condition. "ConditionUnknown" means kubernetes
+// can't decide if a resource is in the condition or not. In the future, we could add other
+// intermediate conditions, e.g. ConditionDegraded.
+const (
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
+)
+
+// Condition contains details for one aspect of the current state of this API Resource.
+// ---
+// This struct is intended for direct use as an array at the field path .status.conditions.  For example,
+//
+//	type FooStatus struct{
+//	    // Represents the observations of a foo's current state.
+//	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
+//	    // +patchMergeKey=type
+//	    // +patchStrategy=merge
+//	    // +listType=map
+//	    // +listMapKey=type
+//	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+//
+//	    // other fields
+//	}
+type Condition struct {
+	// type of condition in CamelCase or in foo.example.com/CamelCase.
+	// ---
+	// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+	// useful (see .node.status.conditions), the ability to deconflict is important.
+	// The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+	// +kubebuilder:validation:MaxLength=316
+	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
+	// status of the condition, one of True, False, Unknown.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False;Unknown
+	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status"`
+	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the instance.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
+	// lastTransitionTime is the last time the condition transitioned from one status to another.
+	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"`
+	// reason contains a programmatic identifier indicating the reason for the condition's last transition.
+	// Producers of specific condition types may define expected values and meanings for this field,
+	// and whether the values are considered a guaranteed API.
+	// The value should be a CamelCase string.
+	// This field may not be empty.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
+	// message is a human readable message indicating details about the transition.
+	// This may be an empty string.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=32768
+	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
+}

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -33,6 +33,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nofloats"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nomaps"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/nophase"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalfields"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/requiredfields"


### PR DESCRIPTION
Adds a new `notimestamp` linter that checks for any fields in struct having timestamp string or substring.

Fixes: #26
