### PR TITLE
linter: add `namingconventions` linter

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -318,6 +318,7 @@ Naming conventions must have:
 - A human-readable message to be included in violation errors.
 - A regular expression that will match text within the field name that violates the convention.
 - A defined "operation". Allowed operations are `Inform`, `Drop`, `DropField`, and `Replace`.
+
 The `Inform` operation will simply inform when a field name violates the naming convention.
 The `Drop` operation will suggest a fix that drops violating text from the field name.
 The `DropField` operation will suggest a fix that removes the field in it's entirety.
@@ -374,8 +375,8 @@ linterConfig:
 ```yaml
 linterConfig:
   namingconventions:
-    conventions: 
-      - name: englishcolour 
+    conventions:
+      - name: BritishEnglishColour 
         violationMatcher: (?i)color
         operation: Replace
         replace: colour

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -8,6 +8,7 @@
 - [Integers](#integers) - Validates usage of supported integer types
 - [JSONTags](#jsontags) - Ensures proper JSON tag formatting
 - [MaxLength](#maxlength) - Checks for maximum length constraints on strings and arrays
+- [NamingConventions](#namingconventions) - Ensures field names adhere to user-defined naming conventions
 - [NoBools](#nobools) - Prevents usage of boolean types
 - [NoDurations](#nodurations) - Prevents usage of duration types
 - [NoFloats](#nofloats) - Prevents usage of floating-point types
@@ -301,6 +302,85 @@ or `+kubebuilder:validation:items:MaxLenth` if the array is an element of the bu
 
 Adding maximum lengths to strings and arrays not only ensures that the API is not abused (used to store overly large data, reduces DDOS etc.),
 but also allows CEL validation cost estimations to be kept within reasonable bounds.
+
+## NamingConventions
+
+The `namingconventions` linter ensures that field names adhere to a set of defined naming conventions.
+
+By default, `namingconventions` is not enabled.
+
+When enabled, it must be configured with at least one naming convention.
+
+### Configuration
+
+Naming conventions must have:
+- A unique human-readable name.
+- A human-readable message to be included in violation errors.
+- A regular expression that will match text within the field name that violates the convention.
+- A defined "operation". Allowed operations are `Inform`, `Drop`, `DropField`, and `Replace`.
+The `Inform` operation will simply inform when a field name violates the naming convention.
+The `Drop` operation will suggest a fix that drops violating text from the field name.
+The `DropField` operation will suggest a fix that removes the field in it's entirety.
+The `Replace` operation will suggest a fix that replaces the violating text in the field name with a defined replacement value.
+
+High-level configuration overview:
+```yaml
+linterConfig:
+  namingconventions:
+    conventions: 
+      - name: {human readable string} # must be unique
+        violationMatcher: {regular expression}
+        operation: Inform | Drop | DropField | Replace
+        replace: { replacement string } # required when operation is 'Replace', forbidden otherwise
+        message: {human readable string}
+```
+
+Some example configurations:
+
+**Scenario:** Inform that any variations of the word 'fruit' in field names is not allowed
+```yaml
+linterConfig:
+  namingconventions:
+    conventions: 
+      - name: nofruit
+        violationMatcher: (?i)fruit
+        operation: Inform
+        message: fields should not contain any variation of the word 'fruit' in their names
+```
+
+**Scenario:** Drop any variations of the word 'fruit' in field names
+```yaml
+linterConfig:
+  namingconventions:
+    conventions: 
+      - name: nofruit
+        violationMatcher: (?i)fruit
+        operation: Drop
+        message: fields should not contain any variation of the word 'fruit' in their names
+```
+
+**Scenario:** Do not allow fields with any variations of the word 'fruit' in their name
+```yaml
+linterConfig:
+  namingconventions:
+    conventions: 
+      - name: nofruit
+        violationMatcher: (?i)fruit
+        operation: DropField
+        message: fields should not contain any variation of the word 'fruit' in their names
+```
+
+**Scenario:** Replace any variations of the word 'color' with 'colour' in field names
+```yaml
+linterConfig:
+  namingconventions:
+    conventions: 
+      - name: englishcolour 
+        violationMatcher: (?i)color
+        operation: Replace
+        replace: colour
+        message: prefer 'colour' over 'color' when referring to colours in field names
+```
 
 ## NoBools
 

--- a/pkg/analysis/namingconventions/analyzer.go
+++ b/pkg/analysis/namingconventions/analyzer.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package namingconventions
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+)
+
+const name = "namingconventions"
+
+type analyzer struct {
+	conventions []Convention
+}
+
+// newAnalyzer creates a new analysis.Analyzer for the namingconventions
+// linter based on the provided config.
+func newAnalyzer(cfg *Config) *analysis.Analyzer {
+	a := &analyzer{
+		conventions: cfg.Conventions,
+	}
+
+	analyzer := &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Enforces naming conventions on fields",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspector.Analyzer, extractjsontags.Analyzer},
+	}
+
+	return analyzer
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (any, error) {
+	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	if !ok {
+		return nil, kalerrors.ErrCouldNotGetInspector
+	}
+
+	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTags extractjsontags.FieldTagInfo, markersAccess markers.Markers) {
+		checkField(pass, field, jsonTags, a.conventions...)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo, conventions ...Convention) {
+	if field == nil || len(field.Names) == 0 {
+		return
+	}
+
+	fieldName := utils.FieldName(field)
+
+	for _, convention := range conventions {
+		// regexp.MustCompile will panic if the regular expression doesn't compile.
+		// This should be reasonable as any regular expressions in naming conventions
+		// will have already been validated to compile during the configuration validation stage.
+		matcher := regexp.MustCompile(convention.ViolationMatcher)
+
+		if !matcher.MatchString(fieldName) && !matcher.MatchString(tagInfo.Name) {
+			continue
+		}
+
+		switch convention.Operation {
+		case OperationInform:
+			reportConventionWithSuggestedFixes(pass, field, convention)
+
+		case OperationDropField:
+			reportDropField(pass, field, convention)
+
+		case OperationDrop:
+			reportDrop(pass, field, tagInfo, convention, matcher)
+
+		case OperationReplace:
+			reportReplace(pass, field, tagInfo, convention, matcher)
+		}
+	}
+}
+
+func reportConventionWithSuggestedFixes(pass *analysis.Pass, field *ast.Field, convention Convention, suggestedFixes ...analysis.SuggestedFix) {
+	pass.Report(analysis.Diagnostic{
+		Pos:            field.Pos(),
+		Message:        fmt.Sprintf("naming convention %q: %s", convention.Name, convention.Message),
+		SuggestedFixes: suggestedFixes,
+	})
+}
+
+func reportDropField(pass *analysis.Pass, field *ast.Field, convention Convention) {
+	suggestedFixes := []analysis.SuggestedFix{}
+	suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+		Message: "remove the field",
+		TextEdits: []analysis.TextEdit{
+			{
+				Pos:     field.Pos(),
+				NewText: []byte(""),
+				End:     field.End(),
+			},
+		},
+	})
+
+	reportConventionWithSuggestedFixes(pass, field, convention, suggestedFixes...)
+}
+
+func reportDrop(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo, convention Convention, matcher *regexp.Regexp) {
+	suggestedFixes := suggestedFixesForReplacement(field, tagInfo, matcher, "")
+	reportConventionWithSuggestedFixes(pass, field, convention, suggestedFixes...)
+}
+
+func reportReplace(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo, convention Convention, matcher *regexp.Regexp) {
+	suggestedFixes := suggestedFixesForReplacement(field, tagInfo, matcher, convention.Replace)
+	reportConventionWithSuggestedFixes(pass, field, convention, suggestedFixes...)
+}
+
+func suggestedFixesForReplacement(field *ast.Field, tagInfo extractjsontags.FieldTagInfo, matcher *regexp.Regexp, replacementStr string) []analysis.SuggestedFix {
+	suggestedFixes := []analysis.SuggestedFix{}
+
+	suggestedFixes = append(suggestedFixes, suggestFixesForGoFieldName(field, matcher, replacementStr)...)
+	suggestedFixes = append(suggestedFixes, suggestFixesForSerializedFieldName(tagInfo, matcher, replacementStr)...)
+
+	return suggestedFixes
+}
+
+func suggestFixesForSerializedFieldName(tagInfo extractjsontags.FieldTagInfo, matcher *regexp.Regexp, replacementStr string) []analysis.SuggestedFix {
+	replacement := matcher.ReplaceAllString(tagInfo.Name, replacementStr)
+
+	// If dropping the offending text from the field name would result in an empty
+	// field name, just issue the failure with no suggested fix.
+	if len(replacement) == 0 {
+		return nil
+	}
+
+	suggestedFixes := []analysis.SuggestedFix{}
+
+	// This should prevent panics from slice access when the replacement
+	// string ends up being a length of 1 and still result in a technically
+	// correct JSON tag name value.
+	tagNameReplacement := strings.ToLower(replacement)
+	if len(replacement) > 1 {
+		tagNameReplacement = fmt.Sprintf("%s%s", strings.ToLower(replacement[:1]), replacement[1:])
+	}
+
+	tagReplacement := strings.ReplaceAll(tagInfo.RawValue, tagInfo.Name, tagNameReplacement)
+
+	tagReplacementMessage := fmt.Sprintf("replace offending text in serialized field name with %q", replacementStr)
+
+	if len(replacementStr) == 0 {
+		tagReplacementMessage = "remove offending text from serialized field name"
+	}
+
+	suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+		Message: tagReplacementMessage,
+		TextEdits: []analysis.TextEdit{
+			{
+				Pos:     tagInfo.Pos,
+				NewText: []byte(tagReplacement),
+				End:     tagInfo.End,
+			},
+		},
+	})
+
+	return suggestedFixes
+}
+
+func suggestFixesForGoFieldName(field *ast.Field, matcher *regexp.Regexp, replacementStr string) []analysis.SuggestedFix {
+	fieldName := utils.FieldName(field)
+	replacement := matcher.ReplaceAllString(fieldName, replacementStr)
+
+	// If dropping the offending text from the field name would result in an empty
+	// field name, just issue the failure with no suggested fix.
+	if len(replacement) == 0 {
+		return nil
+	}
+
+	suggestedFixes := []analysis.SuggestedFix{}
+
+	replacementMessage := fmt.Sprintf("replace offending text in Go type with %q", replacementStr)
+
+	if len(replacementStr) == 0 {
+		replacementMessage = "remove offending text from Go type field"
+	}
+
+	suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
+		Message: replacementMessage,
+		TextEdits: []analysis.TextEdit{
+			{
+				Pos:     field.Pos(),
+				NewText: []byte(replacement),
+				End:     field.Pos() + token.Pos(len(fieldName)),
+			},
+		},
+	})
+
+	return suggestedFixes
+}

--- a/pkg/analysis/namingconventions/analyzer_test.go
+++ b/pkg/analysis/namingconventions/analyzer_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package namingconventions_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/namingconventions"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+
+	cfg := &namingconventions.Config{
+		Conventions: []namingconventions.Convention{
+			{
+				Name:             "nofruit",
+				ViolationMatcher: "(?i)fruit",
+				Operation:        namingconventions.OperationDrop,
+				Message:          "no fields should contain any variations of the word 'fruit' in their name.",
+			},
+			{
+				Name:             "preferbehaviour",
+				ViolationMatcher: "(?i)behavior",
+				Operation:        namingconventions.OperationReplace,
+				Message:          "prefer the use of the word 'behaviour' instead of 'behavior'.",
+				Replace:          "Behaviour",
+			},
+			{
+				Name:             "nounsupported",
+				ViolationMatcher: "(?i)unsupported",
+				Operation:        namingconventions.OperationDropField,
+				Message:          "no fields allowing for unsupported behaviors allowed",
+			},
+			{
+				Name:             "notest",
+				ViolationMatcher: "(?i)test",
+				Operation:        namingconventions.OperationInform,
+				Message:          "no temporary test fields",
+			},
+		},
+	}
+
+	analyzer, err := namingconventions.Initializer().Init(cfg)
+	if err != nil {
+		t.Fatalf("initializing namingconventions linter: %v", err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "a")
+}

--- a/pkg/analysis/namingconventions/analyzer_test.go
+++ b/pkg/analysis/namingconventions/analyzer_test.go
@@ -36,9 +36,9 @@ func Test(t *testing.T) {
 			{
 				Name:             "preferbehaviour",
 				ViolationMatcher: "(?i)behavior",
-				Operation:        namingconventions.OperationReplace,
+				Operation:        namingconventions.OperationReplacement,
 				Message:          "prefer the use of the word 'behaviour' instead of 'behavior'.",
-				Replace:          "Behaviour",
+				Replacement:      "Behaviour",
 			},
 			{
 				Name:             "nounsupported",

--- a/pkg/analysis/namingconventions/config.go
+++ b/pkg/analysis/namingconventions/config.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package namingconventions
+
+// Config represents the configuration
+// of the namingconventions linter.
+type Config struct {
+	// conventions is the set of field naming
+	// conventions to be enforced by the namingconventions
+	// linter.
+	// At least one convention is required.
+	// Conventions must be unique, keyed on convention names.
+	Conventions []Convention `json:"conventions,omitempty"`
+}
+
+// Convention represents a naming convention.
+type Convention struct {
+	// name is a required human-readable name to
+	// associate with the field naming convention.
+	Name string `json:"name,omitempty"`
+
+	// violationMatcher is a required regular expression
+	// used to identify violating portions of a field name.
+	ViolationMatcher string `json:"violationMatcher,omitempty"`
+
+	// operation is a required configuration that tells
+	// the namingconventions linter how violations
+	// of this convention should be handled.
+	//
+	// Allowed values are Inform, DropField, Drop, and Replace.
+	//
+	// When set to Inform, the namingconventions linter will
+	// inform when a field is violating the convention, but
+	// will not suggest any fixes.
+	//
+	// When set to DropField, the namingconventions linter will
+	// suggest that any fields matching this convention should
+	// be removed in their entirety.
+	//
+	// When set to Drop, the namingconventions linter will suggest
+	// that any fields matching this convention should drop the
+	// portion of the field name matched by the violationMatcher
+	// expression.
+	//
+	// When set to Replace, the namingconventions linter will
+	// suggest that any fields matching this conventions should
+	// replace the matched portion of the field name with the value
+	// specified in the replace field.
+	Operation Operation `json:"operation,omitempty"`
+
+	// replace configures the string that should
+	// replace the matched portion of a field name
+	// that violates this conventions.
+	// replace is required when operation is set to Replace
+	// and forbidden otherwise.
+	Replace string `json:"replace,omitempty,omitzero"`
+
+	// message is a required human-readable message
+	// to be included in the linter error if a field
+	// is found to violate this naming convention.
+	Message string `json:"message,omitempty"`
+}
+
+// Operation is a reference to the operation that should be used
+// when evaluating a naming convention.
+type Operation string
+
+const (
+	// OperationDropField signals that an entire field
+	// should be removed when the naming convention is violated.
+	OperationDropField Operation = "DropField"
+
+	// OperationDrop signals that the offending text
+	// should be removed from the field name when
+	// the naming convention is violated.
+	OperationDrop Operation = "Drop"
+
+	// OperationReplace signals that the offending text
+	// should be replaced in the field name when
+	// the naming convention is violated.
+	OperationReplace Operation = "Replace"
+
+	// OperationInform signals that no action
+	// should be taken, beyond issuing a linter error
+	// when the naming convention is violated.
+	OperationInform Operation = "Inform"
+)

--- a/pkg/analysis/namingconventions/config.go
+++ b/pkg/analysis/namingconventions/config.go
@@ -30,9 +30,10 @@ type Config struct {
 type Convention struct {
 	// name is a required human-readable name to
 	// associate with the field naming convention.
+	// name is case-sensitive.
 	Name string `json:"name,omitempty"`
 
-	// violationMatcher is a required regular expression
+	// violationMatcher is a required RE2 compliant regular expression
 	// used to identify violating portions of a field name.
 	ViolationMatcher string `json:"violationMatcher,omitempty"`
 
@@ -55,18 +56,18 @@ type Convention struct {
 	// portion of the field name matched by the violationMatcher
 	// expression.
 	//
-	// When set to Replace, the namingconventions linter will
+	// When set to Replacement, the namingconventions linter will
 	// suggest that any fields matching this conventions should
 	// replace the matched portion of the field name with the value
 	// specified in the replace field.
 	Operation Operation `json:"operation,omitempty"`
 
-	// replace configures the string that should
+	// replacement configures the string that should
 	// replace the matched portion of a field name
 	// that violates this conventions.
-	// replace is required when operation is set to Replace
+	// replacement is required when operation is set to Replacement
 	// and forbidden otherwise.
-	Replace string `json:"replace,omitempty,omitzero"`
+	Replacement string `json:"replacement,omitempty,omitzero"`
 
 	// message is a required human-readable message
 	// to be included in the linter error if a field
@@ -88,10 +89,10 @@ const (
 	// the naming convention is violated.
 	OperationDrop Operation = "Drop"
 
-	// OperationReplace signals that the offending text
+	// OperationReplacement signals that the offending text
 	// should be replaced in the field name when
 	// the naming convention is violated.
-	OperationReplace Operation = "Replace"
+	OperationReplacement Operation = "Replacement"
 
 	// OperationInform signals that no action
 	// should be taken, beyond issuing a linter error

--- a/pkg/analysis/namingconventions/doc.go
+++ b/pkg/analysis/namingconventions/doc.go
@@ -26,6 +26,7 @@ Naming conventions must have:
 - A human-readable message to be included in violation errors.
 - A regular expression that will match text within the field name that violates the convention.
 - A defined "operation". Allowed operations are "Inform", "Drop", "DropField", and "Replace".
+
 The "Inform" operation will simply inform via a linter error when a field name violates the naming convention.
 The "Drop" operation will suggest a fix that drops violating text from the field name.
 The "DropField" operation will suggest a fix that removes the field in it's entirety.
@@ -78,10 +79,10 @@ linterConfig:
 
 	namingconventions:
 	  conventions:
-	    - name: englishcolour
+	    - name: BritishEnglishColour
 	      violationMatcher: (?i)color
-	      operation: Replace
-	      replace: colour
+	      operation: Replacement
+	      replacement: colour
 	      message: prefer 'colour' over 'color' when referring to colours in field names
 
 ```

--- a/pkg/analysis/namingconventions/doc.go
+++ b/pkg/analysis/namingconventions/doc.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+The `namingconventions` linter ensures that field names adhere to a set of defined naming conventions.
+
+By default, `namingconventions` is not enabled.
+
+When enabled, it must be configured with at least one naming convention.
+
+Naming conventions must have:
+- A unique human-readable name.
+- A human-readable message to be included in violation errors.
+- A regular expression that will match text within the field name that violates the convention.
+- A defined "operation". Allowed operations are "Inform", "Drop", "DropField", and "Replace".
+The "Inform" operation will simply inform via a linter error when a field name violates the naming convention.
+The "Drop" operation will suggest a fix that drops violating text from the field name.
+The "DropField" operation will suggest a fix that removes the field in it's entirety.
+The "Replace" operation will suggest a fix that replaces the violating text in the field name with a defined replacement value.
+
+Some example configurations:
+
+**Scenario:** Inform that any variations of the word 'fruit' in field names is not allowed
+```yaml
+linterConfig:
+
+	namingconventions:
+	  conventions:
+	    - name: nofruit
+	      violationMatcher: (?i)fruit
+	      operation: Inform
+	      message: fields should not contain any variation of the word 'fruit' in their names
+
+```
+
+**Scenario:** Drop any variations of the word 'fruit' in field names
+```yaml
+linterConfig:
+
+	namingconventions:
+	  conventions:
+	    - name: nofruit
+	      violationMatcher: (?i)fruit
+	      operation: Drop
+	      message: fields should not contain any variation of the word 'fruit' in their names
+
+```
+
+**Scenario:** Do not allow fields with any variations of the word 'fruit' in their name
+```yaml
+linterConfig:
+
+	namingconventions:
+	  conventions:
+	    - name: nofruit
+	      violationMatcher: (?i)fruit
+	      operation: DropField
+	      message: fields should not contain any variation of the word 'fruit' in their names
+
+```
+
+**Scenario:** Replace any variations of the word 'color' with 'colour' in field names
+```yaml
+linterConfig:
+
+	namingconventions:
+	  conventions:
+	    - name: englishcolour
+	      violationMatcher: (?i)color
+	      operation: Replace
+	      replace: colour
+	      message: prefer 'colour' over 'color' when referring to colours in field names
+
+```
+*/
+package namingconventions

--- a/pkg/analysis/namingconventions/initializer.go
+++ b/pkg/analysis/namingconventions/initializer.go
@@ -76,7 +76,6 @@ func validateConventions(fldPath *field.Path, conventions ...Convention) field.E
 	return fieldErrs
 }
 
-// The cyclop linter says this has cyclomatic complexity of 15.
 func validateConvention(fldPath *field.Path, convention Convention) field.ErrorList {
 	fieldErrs := field.ErrorList{}
 
@@ -98,32 +97,32 @@ func validateConvention(fldPath *field.Path, convention Convention) field.ErrorL
 	}
 
 	fieldErrs = append(fieldErrs, validateOperation(fldPath.Child("operation"), convention.Operation)...)
-	fieldErrs = append(fieldErrs, validateReplace(fldPath.Child("replace"), convention.Operation, matcher, convention.Replace)...)
+	fieldErrs = append(fieldErrs, validateReplace(fldPath.Child("replacement"), convention.Operation, matcher, convention.Replacement)...)
 
 	return fieldErrs
 }
 
 func validateOperation(fldPath *field.Path, operation Operation) field.ErrorList {
-	allowedOperations := sets.New(OperationDrop, OperationInform, OperationReplace, OperationDropField)
+	allowedOperations := sets.New(OperationDrop, OperationInform, OperationReplacement, OperationDropField)
 
 	if len(operation) == 0 {
 		return field.ErrorList{field.Required(fldPath, "operation is required")}
 	}
 
 	if len(operation) > 0 && !allowedOperations.Has(operation) {
-		return field.ErrorList{field.Invalid(fldPath, operation, fmt.Sprintf("operation must be one of %q, %q, %q, or %q", OperationInform, OperationDrop, OperationDropField, OperationReplace))}
+		return field.ErrorList{field.Invalid(fldPath, operation, fmt.Sprintf("operation must be one of %q, %q, %q, or %q", OperationInform, OperationDrop, OperationDropField, OperationReplacement))}
 	}
 
 	return field.ErrorList{}
 }
 
 func validateReplace(fldPath *field.Path, operation Operation, matcher *regexp.Regexp, replace string) field.ErrorList {
-	if (len(replace) > 0 && operation != OperationReplace) || (len(replace) == 0 && operation == OperationReplace) {
-		return field.ErrorList{field.Invalid(fldPath, replace, "replace must be specified when operation is 'Replace' and is forbidden otherwise")}
+	if (len(replace) > 0 && operation != OperationReplacement) || (len(replace) == 0 && operation == OperationReplacement) {
+		return field.ErrorList{field.Invalid(fldPath, replace, "replacement must be specified when operation is 'Replacement' and is forbidden otherwise")}
 	}
 
-	if len(replace) > 0 && operation == OperationReplace && matcher.MatchString(replace) {
-		return field.ErrorList{field.Invalid(fldPath, replace, "replace must not match violationMatcher")}
+	if len(replace) > 0 && operation == OperationReplacement && matcher.MatchString(replace) {
+		return field.ErrorList{field.Invalid(fldPath, replace, "replacement must not be matched by violationMatcher")}
 	}
 
 	return field.ErrorList{}

--- a/pkg/analysis/namingconventions/initializer.go
+++ b/pkg/analysis/namingconventions/initializer.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package namingconventions
+
+import (
+	"fmt"
+	"regexp"
+
+	"golang.org/x/tools/go/analysis"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/registry"
+)
+
+func init() {
+	registry.DefaultRegistry().RegisterLinter(Initializer())
+}
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer.AnalyzerInitializer {
+	return initializer.NewConfigurableInitializer(
+		name,
+		initAnalyzer,
+		false,
+		validateConfig,
+	)
+}
+
+func initAnalyzer(cfg *Config) (*analysis.Analyzer, error) {
+	return newAnalyzer(cfg), nil
+}
+
+// validateConfig implements validation of the conditions linter config.
+func validateConfig(cfg *Config, fldPath *field.Path) field.ErrorList {
+	if cfg == nil {
+		return field.ErrorList{field.Required(fldPath, "configuration is required for the namingconventions linter when it is enabled")}
+	}
+
+	if len(cfg.Conventions) == 0 {
+		return field.ErrorList{field.Required(fldPath.Child("conventions"), "at least one naming convention must be specified when the namingconventions linter is enabled")}
+	}
+
+	return validateConventions(fldPath.Child("conventions"), cfg.Conventions...)
+}
+
+func validateConventions(fldPath *field.Path, conventions ...Convention) field.ErrorList {
+	fieldErrs := field.ErrorList{}
+
+	seenConventions := sets.New[string]()
+
+	for i, convention := range conventions {
+		if seenConventions.Has(convention.Name) {
+			fieldErrs = append(fieldErrs, field.Duplicate(fldPath.Index(i).Child("name"), convention.Name))
+			continue
+		}
+
+		fieldErrs = append(fieldErrs, validateConvention(fldPath.Index(i), convention)...)
+		seenConventions.Insert(convention.Name)
+	}
+
+	return fieldErrs
+}
+
+// The cyclop linter says this has cyclomatic complexity of 15.
+func validateConvention(fldPath *field.Path, convention Convention) field.ErrorList {
+	fieldErrs := field.ErrorList{}
+
+	if len(convention.Name) == 0 {
+		fieldErrs = append(fieldErrs, field.Required(fldPath.Child("name"), "name is required"))
+	}
+
+	if len(convention.ViolationMatcher) == 0 {
+		fieldErrs = append(fieldErrs, field.Required(fldPath.Child("violationMatcher"), "violationMatcher is required"))
+	}
+
+	matcher, err := regexp.Compile(convention.ViolationMatcher)
+	if err != nil {
+		fieldErrs = append(fieldErrs, field.Invalid(fldPath.Child("violationMatcher"), convention.ViolationMatcher, fmt.Sprintf("violationMatcher regular expression failed to compile: %s", err.Error())))
+	}
+
+	if convention.Message == "" {
+		fieldErrs = append(fieldErrs, field.Required(fldPath.Child("message"), "message is required"))
+	}
+
+	fieldErrs = append(fieldErrs, validateOperation(fldPath.Child("operation"), convention.Operation)...)
+	fieldErrs = append(fieldErrs, validateReplace(fldPath.Child("replace"), convention.Operation, matcher, convention.Replace)...)
+
+	return fieldErrs
+}
+
+func validateOperation(fldPath *field.Path, operation Operation) field.ErrorList {
+	allowedOperations := sets.New(OperationDrop, OperationInform, OperationReplace, OperationDropField)
+
+	if len(operation) == 0 {
+		return field.ErrorList{field.Required(fldPath, "operation is required")}
+	}
+
+	if len(operation) > 0 && !allowedOperations.Has(operation) {
+		return field.ErrorList{field.Invalid(fldPath, operation, fmt.Sprintf("operation must be one of %q, %q, %q, or %q", OperationInform, OperationDrop, OperationDropField, OperationReplace))}
+	}
+
+	return field.ErrorList{}
+}
+
+func validateReplace(fldPath *field.Path, operation Operation, matcher *regexp.Regexp, replace string) field.ErrorList {
+	if (len(replace) > 0 && operation != OperationReplace) || (len(replace) == 0 && operation == OperationReplace) {
+		return field.ErrorList{field.Invalid(fldPath, replace, "replace must be specified when operation is 'Replace' and is forbidden otherwise")}
+	}
+
+	if len(replace) > 0 && operation == OperationReplace && matcher.MatchString(replace) {
+		return field.ErrorList{field.Invalid(fldPath, replace, "replace must not match violationMatcher")}
+	}
+
+	return field.ErrorList{}
+}

--- a/pkg/analysis/namingconventions/initializer_test.go
+++ b/pkg/analysis/namingconventions/initializer_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namingconventions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/namingconventions"
+)
+
+var _ = Describe("namingconventions initializer", func() {
+	Context("config validation", func() {
+		type testCase struct {
+			config      *namingconventions.Config
+			expectedErr string
+		}
+
+		DescribeTable("should validate the provided config", func(in testCase) {
+			ci, ok := namingconventions.Initializer().(initializer.ConfigurableAnalyzerInitializer)
+			Expect(ok).To(BeTrue())
+
+			errs := ci.ValidateConfig(in.config, field.NewPath("namingconventions"))
+			if len(in.expectedErr) > 0 {
+				Expect(errs.ToAggregate()).To(MatchError(in.expectedErr))
+			} else {
+				Expect(errs).To(HaveLen(0), "No errors were expected")
+			}
+		},
+			Entry("With a valid namingconventions configuration", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "",
+			}),
+			Entry("With a nil config", testCase{
+				config:      nil,
+				expectedErr: "namingconventions: Required value: configuration is required for the namingconventions linter when it is enabled",
+			}),
+			Entry("With an invalid namingconventions configuration, duplicate convention name", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[1].name: Duplicate value: \"nothing\"",
+			}),
+			Entry("With an invalid namingconventions configuration with empty convention name", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].name: Required value: name is required",
+			}),
+			Entry("With an invalid namingconventions configuration with an empty violationMatcher ", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:      "nothing",
+							Operation: namingconventions.OperationDrop,
+							Message:   "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].violationMatcher: Required value: violationMatcher is required",
+			}),
+			Entry("With an invalid namingconventions configuration with a violationMatcher that doesn't compile", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "!&*@^#(*!@&^$",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].violationMatcher: Invalid value: \"!&*@^#(*!@&^$\": violationMatcher regular expression failed to compile: error parsing regexp: missing argument to repetition operator: `*`",
+			}),
+			Entry("With an invalid namingconventions configuration with an empty message", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].message: Required value: message is required",
+			}),
+			Entry("With an invalid namingconventions configuration with an empty operation", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].operation: Required value: operation is required",
+			}),
+			Entry("With an invalid namingconventions configuration with an unknown operation", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        "Unknown",
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].operation: Invalid value: \"Unknown\": operation must be one of \"Inform\", \"Drop\", \"DropField\", or \"Replace\"",
+			}),
+			Entry("With an invalid namingconventions configuration with a replace when operation is not 'Replace'", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationDrop,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+							Replace:          "item",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"item\": replace must be specified when operation is 'Replace' and is forbidden otherwise",
+			}),
+			Entry("With an invalid namingconventions configuration with no replace when operation is 'Replace'", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationReplace,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"\": replace must be specified when operation is 'Replace' and is forbidden otherwise",
+			}),
+			Entry("With an invalid namingconventions configuration where replacement string matches violationMatcher", testCase{
+				config: &namingconventions.Config{
+					Conventions: []namingconventions.Convention{
+						{
+							Name:             "nothing",
+							ViolationMatcher: "(?i)thing",
+							Operation:        namingconventions.OperationReplace,
+							Message:          "no fields should have any variations of the word 'thing' in their name",
+							Replace:          "anotherthing",
+						},
+					},
+				},
+				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"anotherthing\": replace must not match violationMatcher",
+			}),
+		)
+	})
+})

--- a/pkg/analysis/namingconventions/initializer_test.go
+++ b/pkg/analysis/namingconventions/initializer_test.go
@@ -151,9 +151,9 @@ var _ = Describe("namingconventions initializer", func() {
 						},
 					},
 				},
-				expectedErr: "namingconventions.conventions[0].operation: Invalid value: \"Unknown\": operation must be one of \"Inform\", \"Drop\", \"DropField\", or \"Replace\"",
+				expectedErr: "namingconventions.conventions[0].operation: Invalid value: \"Unknown\": operation must be one of \"Inform\", \"Drop\", \"DropField\", or \"Replacement\"",
 			}),
-			Entry("With an invalid namingconventions configuration with a replace when operation is not 'Replace'", testCase{
+			Entry("With an invalid namingconventions configuration with a replacement when operation is not 'replacement'", testCase{
 				config: &namingconventions.Config{
 					Conventions: []namingconventions.Convention{
 						{
@@ -161,24 +161,24 @@ var _ = Describe("namingconventions initializer", func() {
 							ViolationMatcher: "(?i)thing",
 							Operation:        namingconventions.OperationDrop,
 							Message:          "no fields should have any variations of the word 'thing' in their name",
-							Replace:          "item",
+							Replacement:      "item",
 						},
 					},
 				},
-				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"item\": replace must be specified when operation is 'Replace' and is forbidden otherwise",
+				expectedErr: "namingconventions.conventions[0].replacement: Invalid value: \"item\": replacement must be specified when operation is 'Replacement' and is forbidden otherwise",
 			}),
-			Entry("With an invalid namingconventions configuration with no replace when operation is 'Replace'", testCase{
+			Entry("With an invalid namingconventions configuration with no replacement when operation is 'replacement'", testCase{
 				config: &namingconventions.Config{
 					Conventions: []namingconventions.Convention{
 						{
 							Name:             "nothing",
 							ViolationMatcher: "(?i)thing",
-							Operation:        namingconventions.OperationReplace,
+							Operation:        namingconventions.OperationReplacement,
 							Message:          "no fields should have any variations of the word 'thing' in their name",
 						},
 					},
 				},
-				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"\": replace must be specified when operation is 'Replace' and is forbidden otherwise",
+				expectedErr: "namingconventions.conventions[0].replacement: Invalid value: \"\": replacement must be specified when operation is 'Replacement' and is forbidden otherwise",
 			}),
 			Entry("With an invalid namingconventions configuration where replacement string matches violationMatcher", testCase{
 				config: &namingconventions.Config{
@@ -186,13 +186,13 @@ var _ = Describe("namingconventions initializer", func() {
 						{
 							Name:             "nothing",
 							ViolationMatcher: "(?i)thing",
-							Operation:        namingconventions.OperationReplace,
+							Operation:        namingconventions.OperationReplacement,
 							Message:          "no fields should have any variations of the word 'thing' in their name",
-							Replace:          "anotherthing",
+							Replacement:      "anotherthing",
 						},
 					},
 				},
-				expectedErr: "namingconventions.conventions[0].replace: Invalid value: \"anotherthing\": replace must not match violationMatcher",
+				expectedErr: "namingconventions.conventions[0].replacement: Invalid value: \"anotherthing\": replacement must not be matched by violationMatcher",
 			}),
 		)
 	})

--- a/pkg/analysis/namingconventions/namingconventions_suite_test.go
+++ b/pkg/analysis/namingconventions/namingconventions_suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package namingconventions_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConditions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "namingconventions")
+}

--- a/pkg/analysis/namingconventions/namingconventions_suite_test.go
+++ b/pkg/analysis/namingconventions/namingconventions_suite_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestConditions(t *testing.T) {
+func TestNamingConventions(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "namingconventions")
 }

--- a/pkg/analysis/namingconventions/testdata/src/a/a.go
+++ b/pkg/analysis/namingconventions/testdata/src/a/a.go
@@ -1,0 +1,36 @@
+package a
+
+// Shouldn't care about Go types
+type BasketOfFruit struct {
+	RedFruit    []string `json:"redFruit,omitempty"`    // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	OrangeFruit []string `json:"orangeFruit,omitempty"` // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	GreenFruit  []string `json:"greenFruit,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	FruitBlue   []string `json:"fruitBlue,omitempty"`   // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Fruit       []string `json:"fruit,omitempty"`       // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	AFruit      string   `json:"aFruit,omitempty"`      // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+}
+
+// Shouldn't care about methods
+func (b BasketOfFruit) GrabFruit() string {
+	return "nothing"
+}
+
+// shouldn't care about functions
+func IsFruit(in string) {
+	return
+}
+
+type SpecialBehaviors struct {
+	SomethingBehavior string `json:"somethingBehavior,omitempty"` // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+	BehaviorCrazy     bool   `json:"behaviorCrazy,omitempty"`     // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+}
+
+type Configurations struct {
+	SomeSupportedThingy string `json:"someSupportedThingy,omitempty"`
+	UnsupportedThingy   string `json:"unsupportedThingy,omitempty"` // want `naming convention "nounsupported": no fields allowing for unsupported behaviors allowed`
+}
+
+type TestSet struct {
+	TestName string `json:"testName,omitempty"`  // want `naming convention "notest": no temporary test fields`
+	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": no temporary test fields`
+}

--- a/pkg/analysis/namingconventions/testdata/src/a/a.go
+++ b/pkg/analysis/namingconventions/testdata/src/a/a.go
@@ -2,12 +2,12 @@ package a
 
 // Shouldn't care about Go types
 type BasketOfFruit struct {
-	RedFruit    []string `json:"redFruit,omitempty"`    // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	OrangeFruit []string `json:"orangeFruit,omitempty"` // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	GreenFruit  []string `json:"greenFruit,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	FruitBlue   []string `json:"fruitBlue,omitempty"`   // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	Fruit       []string `json:"fruit,omitempty"`       // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	AFruit      string   `json:"aFruit,omitempty"`      // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	RedFruit    []string `json:"redFruit,omitempty"`    // want `naming convention "nofruit": field RedFruit: no fields should contain any variations of the word 'fruit' in their name`
+	OrangeFruit []string `json:"orangeFruit,omitempty"` // want `naming convention "nofruit": field OrangeFruit: no fields should contain any variations of the word 'fruit' in their name`
+	GreenFruit  []string `json:"greenFruit,omitempty"`  // want `naming convention "nofruit": field GreenFruit: no fields should contain any variations of the word 'fruit' in their name`
+	FruitBlue   []string `json:"fruitBlue,omitempty"`   // want `naming convention "nofruit": field FruitBlue: no fields should contain any variations of the word 'fruit' in their name`
+	Fruit       []string `json:"fruit,omitempty"`       // want `naming convention "nofruit": field Fruit: no fields should contain any variations of the word 'fruit' in their name`
+	AFruit      string   `json:"aFruit,omitempty"`      // want `naming convention "nofruit": field AFruit: no fields should contain any variations of the word 'fruit' in their name`
 }
 
 // Shouldn't care about methods
@@ -21,16 +21,16 @@ func IsFruit(in string) {
 }
 
 type SpecialBehaviors struct {
-	SomethingBehavior string `json:"somethingBehavior,omitempty"` // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
-	BehaviorCrazy     bool   `json:"behaviorCrazy,omitempty"`     // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+	SomethingBehavior string `json:"somethingBehavior,omitempty"` // want `naming convention "preferbehaviour": field SomethingBehavior: prefer the use of the word 'behaviour' instead of 'behavior'.`
+	BehaviorCrazy     bool   `json:"behaviorCrazy,omitempty"`     // want `naming convention "preferbehaviour": field BehaviorCrazy: prefer the use of the word 'behaviour' instead of 'behavior'.`
 }
 
 type Configurations struct {
 	SomeSupportedThingy string `json:"someSupportedThingy,omitempty"`
-	UnsupportedThingy   string `json:"unsupportedThingy,omitempty"` // want `naming convention "nounsupported": no fields allowing for unsupported behaviors allowed`
+	UnsupportedThingy   string `json:"unsupportedThingy,omitempty"` // want `naming convention "nounsupported": field UnsupportedThingy: no fields allowing for unsupported behaviors allowed`
 }
 
 type TestSet struct {
-	TestName string `json:"testName,omitempty"`  // want `naming convention "notest": no temporary test fields`
-	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": no temporary test fields`
+	TestName string `json:"testName,omitempty"`  // want `naming convention "notest": field TestName: no temporary test fields`
+	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": field Other: no temporary test fields`
 }

--- a/pkg/analysis/namingconventions/testdata/src/a/a.go.golden
+++ b/pkg/analysis/namingconventions/testdata/src/a/a.go.golden
@@ -1,0 +1,36 @@
+package a
+
+// Shouldn't care about Go types
+type BasketOfFruit struct {
+	Red    []string `json:"red,omitempty"`    // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Orange []string `json:"orange,omitempty"` // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Green  []string `json:"green,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Blue   []string `json:"blue,omitempty"`   // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Fruit  []string `json:"fruit,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	A      string   `json:"a,omitempty"`      // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+}
+
+// Shouldn't care about methods
+func (b BasketOfFruit) GrabFruit() string {
+	return "nothing"
+}
+
+// shouldn't care about functions
+func IsFruit(in string) {
+	return
+}
+
+type SpecialBehaviors struct {
+	SomethingBehaviour string `json:"somethingBehaviour,omitempty"` // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+	BehaviourCrazy     bool   `json:"behaviourCrazy,omitempty"`     // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+}
+
+type Configurations struct {
+	SomeSupportedThingy string `json:"someSupportedThingy,omitempty"`
+	// want `naming convention "nounsupported": no fields allowing for unsupported behaviors allowed`
+}
+
+type TestSet struct {
+    TestName string `json:"testName,omitempty"` // want `naming convention "notest": no temporary test fields`
+	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": no temporary test fields`
+}

--- a/pkg/analysis/namingconventions/testdata/src/a/a.go.golden
+++ b/pkg/analysis/namingconventions/testdata/src/a/a.go.golden
@@ -2,12 +2,12 @@ package a
 
 // Shouldn't care about Go types
 type BasketOfFruit struct {
-	Red    []string `json:"red,omitempty"`    // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	Orange []string `json:"orange,omitempty"` // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	Green  []string `json:"green,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	Blue   []string `json:"blue,omitempty"`   // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	Fruit  []string `json:"fruit,omitempty"`  // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
-	A      string   `json:"a,omitempty"`      // want `naming convention "nofruit": no fields should contain any variations of the word 'fruit' in their name`
+	Red    []string `json:"red,omitempty"`    // want `naming convention "nofruit": field RedFruit: no fields should contain any variations of the word 'fruit' in their name`
+	Orange []string `json:"orange,omitempty"` // want `naming convention "nofruit": field OrangeFruit: no fields should contain any variations of the word 'fruit' in their name`
+	Green  []string `json:"green,omitempty"`  // want `naming convention "nofruit": field GreenFruit: no fields should contain any variations of the word 'fruit' in their name`
+	Blue   []string `json:"blue,omitempty"`   // want `naming convention "nofruit": field FruitBlue: no fields should contain any variations of the word 'fruit' in their name`
+	Fruit  []string `json:"fruit,omitempty"`  // want `naming convention "nofruit": field Fruit: no fields should contain any variations of the word 'fruit' in their name`
+	A      string   `json:"a,omitempty"`      // want `naming convention "nofruit": field AFruit: no fields should contain any variations of the word 'fruit' in their name`
 }
 
 // Shouldn't care about methods
@@ -21,16 +21,16 @@ func IsFruit(in string) {
 }
 
 type SpecialBehaviors struct {
-	SomethingBehaviour string `json:"somethingBehaviour,omitempty"` // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
-	BehaviourCrazy     bool   `json:"behaviourCrazy,omitempty"`     // want `naming convention "preferbehaviour": prefer the use of the word 'behaviour' instead of 'behavior'.`
+	SomethingBehaviour string `json:"somethingBehaviour,omitempty"` // want `naming convention "preferbehaviour": field SomethingBehavior: prefer the use of the word 'behaviour' instead of 'behavior'.`
+	BehaviourCrazy     bool   `json:"behaviourCrazy,omitempty"`     // want `naming convention "preferbehaviour": field BehaviorCrazy: prefer the use of the word 'behaviour' instead of 'behavior'.`
 }
 
 type Configurations struct {
 	SomeSupportedThingy string `json:"someSupportedThingy,omitempty"`
-	// want `naming convention "nounsupported": no fields allowing for unsupported behaviors allowed`
+	// want `naming convention "nounsupported": field UnsupportedThingy: no fields allowing for unsupported behaviors allowed`
 }
 
 type TestSet struct {
-    TestName string `json:"testName,omitempty"` // want `naming convention "notest": no temporary test fields`
-	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": no temporary test fields`
+    TestName string `json:"testName,omitempty"` // want `naming convention "notest": field TestName: no temporary test fields`
+	Other    string `json:"otherTest,omitempty"` // want `naming convention "notest": field Other: no temporary test fields`
 }

--- a/pkg/analysis/nophase/analyzer.go
+++ b/pkg/analysis/nophase/analyzer.go
@@ -16,81 +16,51 @@ limitations under the License.
 package nophase
 
 import (
-	"go/ast"
-	"strings"
+	"errors"
+	"fmt"
 
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/analysis/passes/inspect"
-	"golang.org/x/tools/go/ast/inspector"
-	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/namingconventions"
 )
 
-const name = "nophase"
+const (
+	name = "nophase"
+	doc  = "phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
+)
 
-// Analyzer is the analyzer for the nophase package.
-// It checks that no struct fields named 'phase', or that contain phase as a
-// substring are present.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspect.Analyzer, extractjsontags.Analyzer},
-}
+var errUnexpectedInitializerType = errors.New("expected namingconventions.Initializer() to be of type initializer.ConfigurableAnalyzerInitializer, but was not")
 
-func run(pass *analysis.Pass) (any, error) {
-	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+func newAnalyzer() *analysis.Analyzer {
+	cfg := &namingconventions.Config{
+		Conventions: []namingconventions.Convention{
+			{
+				Name:             "nophase",
+				ViolationMatcher: "(?i)phase",
+				Operation:        namingconventions.OperationInform,
+				Message:          "phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
+			},
+		},
+	}
+
+	configInit, ok := namingconventions.Initializer().(initializer.ConfigurableAnalyzerInitializer)
 	if !ok {
-		return nil, kalerrors.ErrCouldNotGetInspector
+		panic(fmt.Errorf("getting initializer: %w", errUnexpectedInitializerType))
 	}
 
-	jsonTags, ok := pass.ResultOf[extractjsontags.Analyzer].(extractjsontags.StructFieldTags)
-	if !ok {
-		return nil, kalerrors.ErrCouldNotGetJSONTags
+	errs := configInit.ValidateConfig(cfg, field.NewPath("nophase"))
+	if err := errs.ToAggregate(); err != nil {
+		panic(fmt.Errorf("nophase linter has an invalid namingconventions configuration: %w", err))
 	}
 
-	// Filter to fields so that we can iterate over fields in a struct.
-	nodeFilter := []ast.Node{
-		(*ast.Field)(nil),
+	analyzer, err := configInit.Init(cfg)
+	if err != nil {
+		panic(fmt.Errorf("nophase linter encountered an error initializing wrapped namingconventions analyzer: %w", err))
 	}
 
-	// Preorder visits all the nodes of the AST in depth-first order. It calls
-	// f(n) for each node n before it visits n's children.
-	//
-	// We use the filter defined above, ensuring we only look at struct fields.
-	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		field, ok := n.(*ast.Field)
-		if !ok {
-			return
-		}
+	analyzer.Name = name
+	analyzer.Doc = doc
 
-		if field == nil || len(field.Names) == 0 {
-			return
-		}
-
-		fieldName := utils.FieldName(field)
-
-		// First check if the struct field name contains 'phase'
-		if strings.Contains(strings.ToLower(fieldName), "phase") {
-			pass.Reportf(field.Pos(),
-				"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
-				fieldName,
-			)
-
-			return
-		}
-
-		// Then check if the json serialization of the field contains 'phase'
-		tagInfo := jsonTags.FieldTags(field)
-
-		if strings.Contains(strings.ToLower(tagInfo.Name), "phase") {
-			pass.Reportf(field.Pos(),
-				"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
-				fieldName,
-			)
-		}
-	})
-
-	return nil, nil //nolint:nilnil
+	return analyzer
 }

--- a/pkg/analysis/nophase/analyzer_test.go
+++ b/pkg/analysis/nophase/analyzer_test.go
@@ -13,15 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package nophase
+package nophase_test
 
 import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/nophase"
 )
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.RunWithSuggestedFixes(t, testdata, newAnalyzer(), "a")
+
+	analyzer, err := nophase.Initializer().Init(nil)
+	if err != nil {
+		t.Fatalf("initializing namingconventions linter: %v", err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "a")
 }

--- a/pkg/analysis/nophase/analyzer_test.go
+++ b/pkg/analysis/nophase/analyzer_test.go
@@ -13,16 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package nophase_test
+package nophase
 
 import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/nophase"
 )
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.RunWithSuggestedFixes(t, testdata, nophase.Analyzer, "a")
+	analysistest.RunWithSuggestedFixes(t, testdata, newAnalyzer(), "a")
 }

--- a/pkg/analysis/nophase/initializer.go
+++ b/pkg/analysis/nophase/initializer.go
@@ -29,7 +29,7 @@ func init() {
 func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewInitializer(
 		name,
-		Analyzer,
+		newAnalyzer(),
 		true,
 	)
 }

--- a/pkg/analysis/nophase/testdata/src/a/a.go
+++ b/pkg/analysis/nophase/testdata/src/a/a.go
@@ -2,8 +2,7 @@ package a
 
 type NoPhaseTestStruct struct {
 	// +optional
-	Phase *string `json:"phase,omitempty"` // want "field Phase: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
-
+	Phase *string `json:"phase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -11,12 +10,10 @@ func (NoPhaseTestStruct) DoNothing() {}
 
 type NoSubPhaseTestStruct struct {
 	// +optional
-	FooPhase *string `json:"fooPhase,omitempty"` // want "field FooPhase: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
-
+	FooPhase *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }
 
 type SerializedPhaseTeststruct struct {
 	// +optional
-	FooField *string `json:"fooPhase,omitempty"` // want "field FooField: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
-
+	FooField *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }

--- a/pkg/analysis/nophase/testdata/src/a/a.go
+++ b/pkg/analysis/nophase/testdata/src/a/a.go
@@ -2,7 +2,7 @@ package a
 
 type NoPhaseTestStruct struct {
 	// +optional
-	Phase *string `json:"phase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
+	Phase *string `json:"phase,omitempty"` // want "naming convention \"nophase\": field Phase: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -10,10 +10,10 @@ func (NoPhaseTestStruct) DoNothing() {}
 
 type NoSubPhaseTestStruct struct {
 	// +optional
-	FooPhase *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
+	FooPhase *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": field FooPhase: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }
 
 type SerializedPhaseTeststruct struct {
 	// +optional
-	FooField *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
+	FooField *string `json:"fooPhase,omitempty"` // want "naming convention \"nophase\": field FooField: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields"
 }

--- a/pkg/analysis/notimestamp/analyzer.go
+++ b/pkg/analysis/notimestamp/analyzer.go
@@ -38,9 +38,9 @@ func newAnalyzer() *analysis.Analyzer {
 			{
 				Name:             "notimestamp",
 				ViolationMatcher: "(?i)timestamp",
-				Operation:        namingconventions.OperationReplace,
+				Operation:        namingconventions.OperationReplacement,
 				Message:          "prefer use of the term 'time' over 'timestamp'",
-				Replace:          "Time",
+				Replacement:      "Time",
 			},
 		},
 	}

--- a/pkg/analysis/notimestamp/analyzer.go
+++ b/pkg/analysis/notimestamp/analyzer.go
@@ -13,100 +13,55 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package notimestamp
 
 import (
+	"errors"
 	"fmt"
-	"go/ast"
-	"go/token"
-	"regexp"
-	"strings"
 
 	"golang.org/x/tools/go/analysis"
-	kalerrors "sigs.k8s.io/kube-api-linter/pkg/analysis/errors"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/extractjsontags"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/inspector"
-	markershelper "sigs.k8s.io/kube-api-linter/pkg/analysis/helpers/markers"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/utils"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/initializer"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/namingconventions"
 )
 
-const name = "notimestamp"
+const (
+	name = "notimestamp"
+	doc  = "Suggest the usage of the term 'time' over 'timestamp'"
+)
 
-// Analyzer is the analyzer for the notimestamp package.
-// It checks that no struct fields named 'timestamp', or that contain timestamp as a
-// substring are present.
-var Analyzer = &analysis.Analyzer{
-	Name:     name,
-	Doc:      "Suggest the usage of the term 'time' over 'timestamp'",
-	Run:      run,
-	Requires: []*analysis.Analyzer{inspector.Analyzer},
-}
+var errUnexpectedInitializerType = errors.New("expected namingconventions.Initializer() to be of type initializer.ConfigurableAnalyzerInitializer, but was not")
 
-// case-insensitive regular expression to match 'timestamp' string in field or json tag.
-var timeStampRegEx = regexp.MustCompile("(?i)timestamp")
+func newAnalyzer() *analysis.Analyzer {
+	cfg := &namingconventions.Config{
+		Conventions: []namingconventions.Convention{
+			{
+				Name:             "notimestamp",
+				ViolationMatcher: "(?i)timestamp",
+				Operation:        namingconventions.OperationReplace,
+				Message:          "prefer use of the term 'time' over 'timestamp'",
+				Replace:          "Time",
+			},
+		},
+	}
 
-func run(pass *analysis.Pass) (any, error) {
-	inspect, ok := pass.ResultOf[inspector.Analyzer].(inspector.Inspector)
+	configInit, ok := namingconventions.Initializer().(initializer.ConfigurableAnalyzerInitializer)
 	if !ok {
-		return nil, kalerrors.ErrCouldNotGetInspector
+		panic(fmt.Errorf("getting initializer: %w", errUnexpectedInitializerType))
 	}
 
-	inspect.InspectFields(func(field *ast.Field, stack []ast.Node, jsonTagInfo extractjsontags.FieldTagInfo, markersAccess markershelper.Markers) {
-		checkFieldsAndTags(pass, field, jsonTagInfo)
-	})
-
-	return nil, nil //nolint:nilnil
-}
-
-func checkFieldsAndTags(pass *analysis.Pass, field *ast.Field, tagInfo extractjsontags.FieldTagInfo) {
-	fieldName := utils.FieldName(field)
-	if fieldName == "" {
-		return
+	errs := configInit.ValidateConfig(cfg, field.NewPath("notimestamp"))
+	if err := errs.ToAggregate(); err != nil {
+		panic(fmt.Errorf("notimestamp linter has an invalid namingconventions configuration: %w", err))
 	}
 
-	var suggestedFixes []analysis.SuggestedFix
-
-	// check if filed name contains timestamp in it.
-	fieldReplacementName := timeStampRegEx.ReplaceAllString(fieldName, "Time")
-	if fieldReplacementName != fieldName {
-		suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
-			Message: fmt.Sprintf("replace %s with %s", fieldName, fieldReplacementName),
-			TextEdits: []analysis.TextEdit{
-				{
-					Pos:     field.Pos(),
-					NewText: []byte(fieldReplacementName),
-					End:     field.Pos() + token.Pos(len(fieldName)),
-				},
-			},
-		})
+	analyzer, err := configInit.Init(cfg)
+	if err != nil {
+		panic(fmt.Errorf("notimestamp linter encountered an error initializing wrapped namingconventions analyzer: %w", err))
 	}
 
-	// check if the tag contains timestamp in it.
-	tagReplacementName := timeStampRegEx.ReplaceAllString(tagInfo.Name, "Time")
-	if strings.HasPrefix(strings.ToLower(tagInfo.Name), "time") {
-		// If the tag starts with 'timeStamp', the replacement should be 'time' not 'Time'.
-		tagReplacementName = timeStampRegEx.ReplaceAllString(tagInfo.Name, "time")
-	}
+	analyzer.Name = name
+	analyzer.Doc = doc
 
-	if tagReplacementName != tagInfo.Name {
-		suggestedFixes = append(suggestedFixes, analysis.SuggestedFix{
-			Message: fmt.Sprintf("replace %s json tag with %s", tagInfo.Name, tagReplacementName),
-			TextEdits: []analysis.TextEdit{
-				{
-					Pos:     tagInfo.Pos,
-					NewText: []byte(tagReplacementName),
-					End:     tagInfo.Pos + token.Pos(len(tagInfo.Name)),
-				},
-			},
-		})
-	}
-
-	if len(suggestedFixes) > 0 {
-		pass.Report(analysis.Diagnostic{
-			Pos:            field.Pos(),
-			Message:        fmt.Sprintf("field %s: prefer use of the term time over timestamp", fieldName),
-			SuggestedFixes: suggestedFixes,
-		})
-	}
+	return analyzer
 }

--- a/pkg/analysis/notimestamp/analyzer_test.go
+++ b/pkg/analysis/notimestamp/analyzer_test.go
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package notimestamp_test
+package notimestamp
 
 import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
-	"sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
 )
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.RunWithSuggestedFixes(t, testdata, notimestamp.Analyzer, "a")
+	analysistest.RunWithSuggestedFixes(t, testdata, newAnalyzer(), "a")
 }

--- a/pkg/analysis/notimestamp/analyzer_test.go
+++ b/pkg/analysis/notimestamp/analyzer_test.go
@@ -14,15 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package notimestamp
+package notimestamp_test
 
 import (
 	"testing"
 
 	"golang.org/x/tools/go/analysis/analysistest"
+	"sigs.k8s.io/kube-api-linter/pkg/analysis/notimestamp"
 )
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.RunWithSuggestedFixes(t, testdata, newAnalyzer(), "a")
+
+	analyzer, err := notimestamp.Initializer().Init(nil)
+	if err != nil {
+		t.Fatalf("initializing namingconventions linter: %v", err)
+	}
+
+	analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "a")
 }

--- a/pkg/analysis/notimestamp/initializer.go
+++ b/pkg/analysis/notimestamp/initializer.go
@@ -30,7 +30,7 @@ func init() {
 func Initializer() initializer.AnalyzerInitializer {
 	return initializer.NewInitializer(
 		name,
-		Analyzer,
+		newAnalyzer(),
 		true,
 	)
 }

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go
@@ -8,28 +8,28 @@ import (
 
 type NoTimeStampTestStruct struct {
 	// +optional
-	TimeStamp *time.Time `json:"timeStamp,omitempty"` // want "field TimeStamp: prefer use of the term time over timestamp"
+	TimeStamp *time.Time `json:"timeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	Timestamp *time.Time `json:"timestamp,omitempty"` // want "field Timestamp: prefer use of the term time over timestamp"
+	Timestamp *time.Time `json:"timestamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FootimeStamp *time.Time `json:"footimeStamp,omitempty"` // want "field FootimeStamp: prefer use of the term time over timestamp"
+	FootimeStamp *time.Time `json:"footimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	BarTimestamp *time.Time `json:"barTimestamp,omitempty"` // want "field BarTimestamp: prefer use of the term time over timestamp"
+	BarTimestamp *time.Time `json:"barTimestamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FootimestampBar *time.Time `json:"fooTimestampBar,omitempty"` // want "field FootimestampBar: prefer use of the term time over timestamp"
+	FootimestampBar *time.Time `json:"fooTimestampBar,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimestampBarTimeStamp *time.Time `json:"fooTimestampBarTimeStamp,omitempty"` // want "field FooTimestampBarTimeStamp: prefer use of the term time over timestamp"
+	FooTimestampBarTimeStamp *time.Time `json:"fooTimestampBarTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	MetaTimeStamp *metav1.Time `json:"metaTimeStamp,omitempty"` // want "field MetaTimeStamp: prefer use of the term time over timestamp"
+	MetaTimeStamp *metav1.Time `json:"metaTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -37,7 +37,7 @@ func (NoTimeStampTestStruct) DoNothing() {}
 
 type NoSubTimeStampTestStruct struct {
 	// +optional
-	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 }
 
 type SerializedTimeStampTestStruct struct {

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go
@@ -8,28 +8,28 @@ import (
 
 type NoTimeStampTestStruct struct {
 	// +optional
-	TimeStamp *time.Time `json:"timeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	TimeStamp *time.Time `json:"timeStamp,omitempty"` // want `naming convention "notimestamp": field TimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	Timestamp *time.Time `json:"timestamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	Timestamp *time.Time `json:"timestamp,omitempty"` // want `naming convention "notimestamp": field Timestamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": field FooTimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FootimeStamp *time.Time `json:"footimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FootimeStamp *time.Time `json:"footimeStamp,omitempty"` // want `naming convention "notimestamp": field FootimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	BarTimestamp *time.Time `json:"barTimestamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	BarTimestamp *time.Time `json:"barTimestamp,omitempty"` // want `naming convention "notimestamp": field BarTimestamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FootimestampBar *time.Time `json:"fooTimestampBar,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FootimestampBar *time.Time `json:"fooTimestampBar,omitempty"` // want `naming convention "notimestamp": field FootimestampBar: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimestampBarTimeStamp *time.Time `json:"fooTimestampBarTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTimestampBarTimeStamp *time.Time `json:"fooTimestampBarTimeStamp,omitempty"` // want `naming convention "notimestamp": field FooTimestampBarTimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	MetaTimeStamp *metav1.Time `json:"metaTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	MetaTimeStamp *metav1.Time `json:"metaTimeStamp,omitempty"` // want `naming convention "notimestamp": field MetaTimeStamp: prefer use of the term 'time' over 'timestamp'`
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -37,7 +37,7 @@ func (NoTimeStampTestStruct) DoNothing() {}
 
 type NoSubTimeStampTestStruct struct {
 	// +optional
-	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTimeStamp *time.Time `json:"fooTimeStamp,omitempty"` // want `naming convention "notimestamp": field FooTimeStamp: prefer use of the term 'time' over 'timestamp'`
 }
 
 type SerializedTimeStampTestStruct struct {

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
@@ -8,28 +8,28 @@ import (
 
 type NoTimeStampTestStruct struct {
 	// +optional
-	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": field TimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": field Timestamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": field FooTimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": field FootimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	BarTime *time.Time `json:"barTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	BarTime *time.Time `json:"barTime,omitempty"` // want `naming convention "notimestamp": field BarTimestamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeBar *time.Time `json:"fooTimeBar,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTimeBar *time.Time `json:"fooTimeBar,omitempty"` // want `naming convention "notimestamp": field FootimestampBar: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeBarTime *time.Time `json:"fooTimeBarTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTimeBarTime *time.Time `json:"fooTimeBarTime,omitempty"` // want `naming convention "notimestamp": field FooTimestampBarTimeStamp: prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	MetaTime *metav1.Time `json:"metaTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	MetaTime *metav1.Time `json:"metaTime,omitempty"` // want `naming convention "notimestamp": field MetaTimeStamp: prefer use of the term 'time' over 'timestamp'`
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -37,7 +37,7 @@ func (NoTimeStampTestStruct) DoNothing() {}
 
 type NoSubTimeStampTestStruct struct {
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": field FooTimeStamp: prefer use of the term 'time' over 'timestamp'`
 }
 
 type SerializedTimeStampTestStruct struct {

--- a/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
+++ b/pkg/analysis/notimestamp/testdata/src/a/a.go.golden
@@ -8,28 +8,28 @@ import (
 
 type NoTimeStampTestStruct struct {
 	// +optional
-	Time *time.Time `json:"time,omitempty"` // want "field TimeStamp: prefer use of the term time over timestamp"
+	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	Time *time.Time `json:"time,omitempty"` // want "field Timestamp: prefer use of the term time over timestamp"
+	Time *time.Time `json:"time,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FootimeStamp: prefer use of the term time over timestamp"
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	BarTime *time.Time `json:"barTime,omitempty"` // want "field BarTimestamp: prefer use of the term time over timestamp"
+	BarTime *time.Time `json:"barTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeBar *time.Time `json:"fooTimeBar,omitempty"` // want "field FootimestampBar: prefer use of the term time over timestamp"
+	FooTimeBar *time.Time `json:"fooTimeBar,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	FooTimeBarTime *time.Time `json:"fooTimeBarTime,omitempty"` // want "field FooTimestampBarTimeStamp: prefer use of the term time over timestamp"
+	FooTimeBarTime *time.Time `json:"fooTimeBarTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 
 	// +optional
-	MetaTime *metav1.Time `json:"metaTime,omitempty"` // want "field MetaTimeStamp: prefer use of the term time over timestamp"
+	MetaTime *metav1.Time `json:"metaTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 }
 
 // DoNothing is used to check that the analyser doesn't report on methods.
@@ -37,7 +37,7 @@ func (NoTimeStampTestStruct) DoNothing() {}
 
 type NoSubTimeStampTestStruct struct {
 	// +optional
-	FooTime *time.Time `json:"fooTime,omitempty"` // want "field FooTimeStamp: prefer use of the term time over timestamp"
+	FooTime *time.Time `json:"fooTime,omitempty"` // want `naming convention "notimestamp": prefer use of the term 'time' over 'timestamp'`
 }
 
 type SerializedTimeStampTestStruct struct {


### PR DESCRIPTION
Adds a new linter, `namingconventions`, that allows for configuration of custom naming conventions to be enforced on both Go type and serialized field names.

Additionally, this PR updates the `nophase` and `notimestamp` linters to wrap the `namingconventions` linter similarly to how the `nonullable` linter wraps the `forbiddenmarkers` linter.

This should make future default field naming convention linters much easier to write, while giving users flexibility to add their own custom naming conventions.