### PR TITLE
Small fixups post refactor and ssatags merge

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -281,7 +281,7 @@ The linter checks for:
 
 ```yaml
 lintersConfig:
-  ssaTags:
+  ssatags:
     listTypeSetUsage: Warn | Ignore # The policy for listType=set usage on object arrays. Defaults to `Warn`.
 ```
 

--- a/pkg/registration/doc.go
+++ b/pkg/registration/doc.go
@@ -36,6 +36,7 @@ import (
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalfields"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/optionalorrequired"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/requiredfields"
+	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/ssatags"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/statusoptional"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/statussubresource"
 	_ "sigs.k8s.io/kube-api-linter/pkg/analysis/uniquemarkers"


### PR DESCRIPTION
When rebasing the refactor, I missed registering the SSATags linter in the new method. And we have a typo in the docs, thanks @sbueringer for noticing 