### PR TITLE
fix(optionalfields): lookup types markers of fields when inspect fields

### DIFF
--- a/pkg/analysis/optionalfields/testdata/src/a/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go
@@ -98,6 +98,20 @@ type A struct {
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
 	PointerMapAlias *MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias is optional but the underlying type does not need to be a pointer. The pointer should be removed."
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// With the "Always" pointer preference, optional fields should be pointers regardless of zero value validity.
+	// +optional
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field StringAliasWithEnum is optional and should be a pointer"
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This is correctly a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"`
+
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and should have the omitempty tag"
 }
 
 type B struct {
@@ -129,3 +143,8 @@ type BoolAlias bool
 type SliceAlias []string
 
 type MapAlias map[string]string
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string

--- a/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/a/a.go.golden
@@ -98,6 +98,20 @@ type A struct {
 	// PointerMapAlias is a pointer map alias field.
 	// +optional
 	PointerMapAlias MapAlias `json:"pointerMapAlias,omitempty"` // want "field PointerMapAlias is optional but the underlying type does not need to be a pointer. The pointer should be removed."
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// With the "Always" pointer preference, optional fields should be pointers regardless of zero value validity.
+	// +optional
+	StringAliasWithEnum *StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"` // want "field StringAliasWithEnum is optional and should be a pointer"
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This is correctly a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"`
+	
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty *StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and should have the omitempty tag"
 }
 
 type B struct {
@@ -129,3 +143,8 @@ type BoolAlias bool
 type SliceAlias []string
 
 type MapAlias map[string]string
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string

--- a/pkg/analysis/optionalfields/testdata/src/b/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/b/a.go
@@ -270,6 +270,24 @@ type A struct {
 	// MapAlias is a map alias field.
 	// +optional
 	MapAlias MapAlias `json:"mapAlias,omitempty"`
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// The zero value ("") is not in the enum, so this should NOT be a pointer.
+	// +optional
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"`
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This should NOT be a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer is optional and does not allow the zero value. The field does not need to be a pointer."
+
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and should have the omitempty tag"
+
+	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
+	// +optional
+	StringAliasWithEnumEmptyValue *StringAliasWithEnumEmptyValue `json:"stringAliasWithEnumEmptyValue,omitempty"`
 }
 
 type B struct {
@@ -308,3 +326,12 @@ type BoolAlias bool
 type SliceAlias []string
 
 type MapAlias map[string]string
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string
+
+// StringAliasWithEnumEmptyValue is a string alias with enum validation and empty value.
+// +kubebuilder:validation:Enum=value1;value2;""
+type StringAliasWithEnumEmptyValue string

--- a/pkg/analysis/optionalfields/testdata/src/b/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/b/a.go.golden
@@ -270,6 +270,24 @@ type A struct {
 	// MapAlias is a map alias field.
 	// +optional
 	MapAlias MapAlias `json:"mapAlias,omitempty"`
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// The zero value ("") is not in the enum, so this should NOT be a pointer.
+	// +optional
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"`
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This should NOT be a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer is optional and does not allow the zero value. The field does not need to be a pointer."
+
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and should have the omitempty tag"
+
+	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
+	// +optional
+	StringAliasWithEnumEmptyValue *StringAliasWithEnumEmptyValue `json:"stringAliasWithEnumEmptyValue,omitempty"`
 }
 
 type B struct {
@@ -308,3 +326,12 @@ type BoolAlias bool
 type SliceAlias []string
 
 type MapAlias map[string]string
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string
+
+// StringAliasWithEnumEmptyValue is a string alias with enum validation and empty value.
+// +kubebuilder:validation:Enum=value1;value2;""
+type StringAliasWithEnumEmptyValue string

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go
@@ -421,6 +421,24 @@ type A struct {
 	// PointerPointerString is a double pointer string field.
 	// +optional
 	DoublePointerString **string `json:"doublePointerString,omitempty"` // want "field DoublePointerString is optional but the underlying type does not need to be a pointer. The pointer should be removed."
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// The zero value ("") is not in the enum, so this should NOT be a pointer.
+	// +optional
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"`
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This should NOT be a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer *StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer is optional and does not allow the zero value. The field does not need to be a pointer."
+
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and does not allow the zero value. It must have the omitempty tag."
+
+	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
+	// +optional
+	StringAliasWithEnumEmptyValue *StringAliasWithEnumEmptyValue `json:"stringAliasWithEnumEmptyValue,omitempty"`
 }
 
 type B struct {
@@ -526,3 +544,12 @@ type G struct {
 	// +kubebuilder:validation:Enum=foo;bar
 	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty"` // want "field EnumWithoutOmitEmpty is optional and does not allow the zero value. It must have the omitempty tag."
 }
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string
+
+// StringAliasWithEnumEmptyValue is a string alias with enum validation and empty value.
+// +kubebuilder:validation:Enum=value1;value2;""
+type StringAliasWithEnumEmptyValue string

--- a/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
+++ b/pkg/analysis/optionalfields/testdata/src/c/a.go.golden
@@ -421,6 +421,24 @@ type A struct {
 	// PointerPointerString is a double pointer string field.
 	// +optional
 	DoublePointerString *string `json:"doublePointerString,omitempty"` // want "field DoublePointerString is optional but the underlying type does not need to be a pointer. The pointer should be removed."
+
+	// StringAliasWithEnum is a string alias field with enum validation.
+	// The zero value ("") is not in the enum, so this should NOT be a pointer.
+	// +optional
+	StringAliasWithEnum StringAliasWithEnum `json:"stringAliasWithEnum,omitempty"`
+
+	// StringAliasWithEnumPointer is a pointer string alias field with enum validation.
+	// This should NOT be a pointer since the zero value is not valid.
+	// +optional
+	StringAliasWithEnumPointer StringAliasWithEnum `json:"stringAliasWithEnumPointer,omitempty"` // want "field StringAliasWithEnumPointer is optional and does not allow the zero value. The field does not need to be a pointer."
+
+	// StringAliasWithEnumNoOmitEmpty is a string alias field with enum validation and no omitempty.
+	// +optional
+	StringAliasWithEnumNoOmitEmpty StringAliasWithEnum `json:"stringAliasWithEnumNoOmitEmpty,omitempty"` // want "field StringAliasWithEnumNoOmitEmpty is optional and does not allow the zero value. It must have the omitempty tag."
+
+	// StringAliasWithEnumEmptyValue is a string alias field with enum validation and empty value.
+	// +optional
+	StringAliasWithEnumEmptyValue *StringAliasWithEnumEmptyValue `json:"stringAliasWithEnumEmptyValue,omitempty"`
 }
 
 type B struct {
@@ -526,3 +544,12 @@ type G struct {
 	// +kubebuilder:validation:Enum=foo;bar
 	EnumWithoutOmitEmpty string `json:"enumWithoutOmitEmpty,omitempty"` // want "field EnumWithoutOmitEmpty is optional and does not allow the zero value. It must have the omitempty tag."
 }
+
+// StringAliasWithEnum is a string alias with enum validation.
+// The zero value ("") is not in the enum, making it invalid.
+// +kubebuilder:validation:Enum=value1;value2
+type StringAliasWithEnum string
+
+// StringAliasWithEnumEmptyValue is a string alias with enum validation and empty value.
+// +kubebuilder:validation:Enum=value1;value2;""
+type StringAliasWithEnumEmptyValue string


### PR DESCRIPTION
fix #113 
- add an option for `util.TypeAwareMarkerCollectionForField` to deref a pointer.
- use `util.TypeAwareMarkerCollectionForField` to lookup types' markers.