### PR TITLE
Add documentation comment to statussubresource analyzer

### DIFF
--- a/pkg/analysis/statussubresource/doc.go
+++ b/pkg/analysis/statussubresource/doc.go
@@ -13,4 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+/*
+The statussubresource linter ensures that a type marked with
+kubebuilder:object:root:=true and containing a status field is marked with
+kubebuilder:subresource:status
+
+Status fields should always be considered a subresource for the API, and this
+way the linter guarantees that the right marker is added on this field.
+
+The linter will report an issue if the root object has a status field and does
+not contain the marker 'kubebuilder:subresource:status'
+*/
 package statussubresource


### PR DESCRIPTION
This change adds the missing documentation comment to "statussubresource" analyzer