### PR TITLE
Update conditions output to include parent struct name

### DIFF
--- a/pkg/analysis/conditions/testdata/src/a/a.go
+++ b/pkg/analysis/conditions/testdata/src/a/a.go
@@ -32,32 +32,32 @@ type ConditionsNotFirst struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
 	// conditions is missing all markers.
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -65,7 +65,7 @@ type MissingListMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -73,7 +73,7 @@ type MissingPatchMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers is missing the following markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingOptionalMarker struct {
@@ -82,7 +82,7 @@ type MissingOptionalMarker struct {
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -92,7 +92,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -102,5 +102,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/a/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/a/a.go.golden
@@ -32,27 +32,27 @@ type ConditionsNotFirst struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
@@ -62,7 +62,7 @@ type MissingAllMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -72,7 +72,7 @@ type MissingListMarkers struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -82,7 +82,7 @@ type MissingPatchMarkers struct {
 	// +optional
 	// +patchStrategy=merge
 	// +patchMergeKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers is missing the following markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingOptionalMarker struct {
@@ -92,7 +92,7 @@ type MissingOptionalMarker struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -102,7 +102,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -112,5 +112,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/b/a.go
+++ b/pkg/analysis/conditions/testdata/src/b/a.go
@@ -50,27 +50,27 @@ type ConditionsThird struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
 	// conditions is missing all markers.
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -78,7 +78,7 @@ type MissingListMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -86,7 +86,7 @@ type MissingPatchMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers is missing the following markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingOptionalMarker struct {
@@ -95,7 +95,7 @@ type MissingOptionalMarker struct {
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -105,7 +105,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -115,5 +115,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/b/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/b/a.go.golden
@@ -50,22 +50,22 @@ type ConditionsThird struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
@@ -75,7 +75,7 @@ type MissingAllMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, patchStrategy=merge, patchMergeKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -85,7 +85,7 @@ type MissingListMarkers struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -95,7 +95,7 @@ type MissingPatchMarkers struct {
 	// +optional
 	// +patchStrategy=merge
 	// +patchMergeKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers is missing the following markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingOptionalMarker struct {
@@ -105,7 +105,7 @@ type MissingOptionalMarker struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -115,7 +115,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -125,5 +125,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/c/a.go
+++ b/pkg/analysis/conditions/testdata/src/c/a.go
@@ -34,22 +34,22 @@ type ValidConditionsMissingProtobuf struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingFieldTag struct {
@@ -59,7 +59,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -69,5 +69,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/c/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/c/a.go.golden
@@ -34,22 +34,22 @@ type ValidConditionsMissingProtobuf struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingFieldTag struct {
@@ -59,7 +59,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -69,5 +69,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/d/a.go
+++ b/pkg/analysis/conditions/testdata/src/d/a.go
@@ -13,7 +13,7 @@ type ValidConditions struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ValidConditions has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 
 	// other fields
 	OtherField string `json:"otherField,omitempty"`
@@ -34,22 +34,22 @@ type ValidConditionsMissingProtobuf struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingFieldTag struct {
@@ -59,7 +59,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -69,5 +69,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/d/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/d/a.go.golden
@@ -13,7 +13,7 @@ type ValidConditions struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field in ValidConditions has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 
 	// other fields
 	OtherField string `json:"otherField,omitempty"`
@@ -34,22 +34,22 @@ type ValidConditionsMissingProtobuf struct {
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingFieldTag struct {
@@ -59,7 +59,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -69,5 +69,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/e/a.go
+++ b/pkg/analysis/conditions/testdata/src/e/a.go
@@ -32,32 +32,32 @@ type ConditionsNotFirst struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
 	// conditions is missing all markers.
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -65,7 +65,7 @@ type MissingListMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -82,7 +82,7 @@ type MissingOptionalMarker struct {
 	// +listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -92,7 +92,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -102,5 +102,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/e/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/e/a.go.golden
@@ -32,27 +32,27 @@ type ConditionsNotFirst struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
@@ -60,7 +60,7 @@ type MissingAllMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, optional"
 }
 
 type MissingListMarkers struct {
@@ -70,7 +70,7 @@ type MissingListMarkers struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -88,7 +88,7 @@ type MissingOptionalMarker struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: optional"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingOptionalMarker is missing the following markers: optional"
 }
 
 type MissingFieldTag struct {
@@ -98,7 +98,7 @@ type MissingFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -108,5 +108,5 @@ type IncorrectFieldTag struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/f/a.go
+++ b/pkg/analysis/conditions/testdata/src/f/a.go
@@ -13,7 +13,7 @@ type ValidConditions struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ValidConditions has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in ValidConditions has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 
 	// other fields
 	OtherField string `json:"otherField,omitempty"`
@@ -32,32 +32,32 @@ type ConditionsNotFirst struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct" "Conditions field in ConditionsNotFirst has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in ConditionsNotFirst has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
 	// conditions is missing all markers.
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field in MissingAllMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type MissingListMarkers struct {
@@ -65,7 +65,7 @@ type MissingListMarkers struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type" "Conditions field in MissingListMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in MissingListMarkers has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -73,7 +73,7 @@ type MissingPatchMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type MissingFieldTag struct {
@@ -81,7 +81,7 @@ type MissingFieldTag struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -89,5 +89,5 @@ type IncorrectFieldTag struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions"  patchMergeKey:"type" protobuf:"bytes,3,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }

--- a/pkg/analysis/conditions/testdata/src/f/a.go.golden
+++ b/pkg/analysis/conditions/testdata/src/f/a.go.golden
@@ -11,7 +11,7 @@ type ValidConditions struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ValidConditions has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in ValidConditions has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 
 	// other fields
 	OtherField string `json:"otherField,omitempty"`
@@ -28,27 +28,27 @@ type ConditionsNotFirst struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field must be the first field in the struct" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in ConditionsNotFirst must be the first field in the struct" "Conditions field in ConditionsNotFirst has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in ConditionsNotFirst has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type ConditionsIncorrectType struct {
 	// conditions has an incorrect type.
-	Conditions map[string]metav1.Condition // want "Conditions field must be a slice of metav1.Condition"
+	Conditions map[string]metav1.Condition // want "Conditions field in ConditionsIncorrectType must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []string // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []string // want "Conditions field in ConditionsIncorrectSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedSliceElement struct {
 	// conditions has an incorrect type.
-	Conditions []metav1.Time // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []metav1.Time // want "Conditions field in ConditionsIncorrectImportedSliceElement must be a slice of metav1.Condition"
 }
 
 type ConditionsIncorrectImportedPackage struct {
 	// conditions has an incorrect type.
-	Conditions []ast.Node // want "Conditions field must be a slice of metav1.Condition"
+	Conditions []ast.Node // want "Conditions field in ConditionsIncorrectImportedPackage must be a slice of metav1.Condition"
 }
 
 type MissingAllMarkers struct {
@@ -56,7 +56,7 @@ type MissingAllMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingAllMarkers is missing the following markers: listType=map, listMapKey=type, optional" "Conditions field in MissingAllMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type MissingListMarkers struct {
@@ -64,7 +64,7 @@ type MissingListMarkers struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=type
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`  // want "Conditions field is missing the following markers: listType=map, listMapKey=type" "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field has the following additional markers: patchStrategy=merge, patchMergeKey=type"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingListMarkers is missing the following markers: listType=map, listMapKey=type" "Conditions field in MissingListMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`" "Conditions field in MissingListMarkers has the following additional markers: patchStrategy=merge, patchMergeKey=type"
 }
 
 type MissingPatchMarkers struct {
@@ -72,7 +72,7 @@ type MissingPatchMarkers struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingPatchMarkers has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type MissingFieldTag struct {
@@ -80,7 +80,7 @@ type MissingFieldTag struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in MissingFieldTag is missing tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }
 
 type IncorrectFieldTag struct {
@@ -88,5 +88,5 @@ type IncorrectFieldTag struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"` // want "Conditions field in IncorrectFieldTag has incorrect tags, should be: `json:\"conditions,omitempty\" protobuf:\"bytes,1,rep,name=conditions\"`"
 }


### PR DESCRIPTION
While looking at adding conditions to K/K, I realised that the current conditions output gives you nothing unique to be able to add exceptions for. You can effectively except at the file level, but this means that future types added to the same files will not be linted for the same exceptions as exist already.

This is a breaking change since it changes the output and that means existing exceptions that folks have will break, but, I think in the long term this will make it easier for folks to handle exceptions for their projects as they will be able to better scope the exceptions.

CC @sbueringer @rikatz In case this effects CAPI/GW API

/assign @everettraven